### PR TITLE
fix: use posix path separators

### DIFF
--- a/graphql_codegen/CHANGELOG.md
+++ b/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.8
+
+Fix bug that generated wrong path separators on Windows.
+
 # 0.4.7
 
 Fix bug in abstract fragment spread with concrete spread on concrete type.

--- a/graphql_codegen/lib/src/printer/context.dart
+++ b/graphql_codegen/lib/src/printer/context.dart
@@ -1,6 +1,8 @@
 import 'package:code_builder/code_builder.dart';
-import 'package:path/path.dart' as p;
+import 'package:path/path.dart' as path;
 import '../context.dart';
+
+final p = path.Context(style: path.Style.posix);
 
 class _Value<TValue> {
   TValue value;

--- a/graphql_codegen/pubspec.yaml
+++ b/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.4.7
+version: 0.4.8
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 


### PR DESCRIPTION
This fixes #1 when the builder is used on Windows.