### PR TITLE
feat: generate $$typename field

### DIFF
--- a/graphql_codegen/CHANGELOG.md
+++ b/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.8
+
+Generate a $$typename field.
+
 # 0.4.7
 
 Fix bug in abstract fragment spread with concrete spread on concrete type.

--- a/graphql_codegen/lib/src/context.dart
+++ b/graphql_codegen/lib/src/context.dart
@@ -473,8 +473,10 @@ abstract class Context<TKey, TType extends TypeDefinitionNode> {
           ) !=
       null;
 
-  Iterable<ContextProperty> get publicProperties =>
-      _properties.values.where((element) => !element._key.startsWith("_"));
+  Iterable<ContextProperty> get publicProperties => _properties.values.where(
+        (element) =>
+            element._key == '__typename' || !element._key.startsWith("_"),
+      );
 
   Name get path => throw StateError("Path not available");
 

--- a/graphql_codegen/lib/src/printer/utils.dart
+++ b/graphql_codegen/lib/src/printer/utils.dart
@@ -104,8 +104,9 @@ String printKeywordSafe(String name) =>
 String printEnumValueName(NameNode name) =>
     printKeywordSafe(ReCase(name.value).camelCase);
 
-String printPropertyName(NameNode name) =>
-    printKeywordSafe(ReCase(name.value).camelCase);
+String printPropertyName(NameNode name) => name.value == '__typename'
+    ? r'$$typename'
+    : printKeywordSafe(ReCase(name.value).camelCase);
 
 Expression printNullCheck(Reference variable, Expression whenNotNull) =>
     variable.equalTo(literalNull).conditional(literalNull, whenNotNull);

--- a/graphql_codegen/pubspec.yaml
+++ b/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.4.7
+version: 0.4.8
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 


### PR DESCRIPTION
There are cases where it's useful to have the typename field generated for distinction between types while not having a distinct selection set for them to tell the difference based on the parsed type.

This PR introduces two tiny changes to make the typename field generate with the name converted to `$$typename` (shamelessly stolen from artemis).

## Note:

I am definitely open to having this configurable! I just wasn't sure where to get the builder's config from in the context to determine whether typename is considered a public property or not.  
If this should be configurable, I would appreciate some guidance on that!