### PR TITLE
fix: generate explicit to json for lists

### DIFF
--- a/graphql_codegen/CHANGELOG.md
+++ b/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.8
+
+Fix bug that caused lists not to serialize to JSON correctly.
+
 # 0.4.7
 
 Fix bug in abstract fragment spread with concrete spread on concrete type.

--- a/graphql_codegen/lib/src/printer/printer.dart
+++ b/graphql_codegen/lib/src/printer/printer.dart
@@ -47,7 +47,10 @@ Spec _printClass(
   return Class(
     (b) => b
       ..annotations = ListBuilder(
-        [_JSON_SERIALIZABLE_BASE_CLASS.call([])],
+        [
+          _JSON_SERIALIZABLE_BASE_CLASS
+              .call([], {'explicitToJson': literalBool(true)})
+        ],
       )
       ..extend = _JSON_SERIALIZABLE_BASE_CLASS
       ..name = name
@@ -334,7 +337,10 @@ Class printContext(PrintContext<ContextOperation> c) {
         context.fragments.map((e) => printClassName(e)).map(refer),
       )
       ..annotations = ListBuilder(
-        [_JSON_SERIALIZABLE_BASE_CLASS.call([])],
+        [
+          _JSON_SERIALIZABLE_BASE_CLASS
+              .call([], {'explicitToJson': literalBool(true)})
+        ],
       )
       ..extend = extendContext == null
           ? _JSON_SERIALIZABLE_BASE_CLASS

--- a/graphql_codegen/pubspec.yaml
+++ b/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.4.7
+version: 0.4.8
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 


### PR DESCRIPTION
Currently the code generated for serializing an object containing a list just places the value in the map:

```dart
Map<String, dynamic> _$QueryExampleToJson(
        QueryExample instance) =>
    <String, dynamic>{
      'someList': instance.someList,
    };
```

Generating `explicitToJson: true` as argument for the `@JsonSerializable()` annotation fixes this issue and now generates this:

```dart
Map<String, dynamic> _$QueryExampleToJson(
        QueryExample instance) =>
    <String, dynamic>{
      'someList': instance.someList.map((e) => e.toJson()).toList(),
    };
```

This PR adds the required code to generate the required argument to correctly serialize objects containing lists.