### PR TITLE
bumped version of gql_code_builder

### DIFF
--- a/graphql_codegen/CHANGELOG.md
+++ b/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.9
+
+bumped version of gql_code_builder
+
 # 0.4.8
 
 Fix bug that generated wrong path separators on Windows.

--- a/graphql_codegen/example/pubspec.lock
+++ b/graphql_codegen/example/pubspec.lock
@@ -182,7 +182,7 @@ packages:
       name: gql_code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0-alpha.0"
   gql_dedupe_link:
     dependency: transitive
     description:
@@ -238,7 +238,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.4.4"
+    version: "0.4.9"
   graphql_codegen_config:
     dependency: transitive
     description:

--- a/graphql_codegen/pubspec.lock
+++ b/graphql_codegen/pubspec.lock
@@ -210,7 +210,7 @@ packages:
       name: gql_code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0-alpha.0"
   gql_dedupe_link:
     dependency: transitive
     description:

--- a/graphql_codegen/pubspec.yaml
+++ b/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.4.8
+version: 0.4.9
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 
@@ -18,7 +18,7 @@ dependencies:
   dart_style: ^2.0.1
   built_collection: ^5.0.0
   path: ^1.8.0
-  gql_code_builder: ^0.2.0
+  gql_code_builder: ^0.3.0-alpha.0
   recase: ^4.0.0
   graphql_codegen_config: ^0.1.0
 


### PR DESCRIPTION
Current version cant be used in app's with analyzer 2.0.0

This update will fix this