### PR TITLE
fix: Recursively build possible types

### DIFF
--- a/graphql_codegen/CHANGELOG.md
+++ b/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.4.9
+
+Fix: Recursively build possible types
+
 # 0.4.8
 
 Fix bug that generated wrong path separators on Windows.

--- a/graphql_codegen/pubspec.yaml
+++ b/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.4.8
+version: 0.4.9
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 

--- a/graphql_codegen/test/assets/possible_types_map/schema.graphql
+++ b/graphql_codegen/test/assets/possible_types_map/schema.graphql
@@ -1,0 +1,27 @@
+union UnionA = InterfaceA | TypeC | TypeA
+
+union UnionB = UnionA | TypeD
+
+interface InterfaceA {
+    name: String
+}
+
+type TypeA implements InterfaceA {
+    name: String
+}
+
+type TypeC {
+    age: Int
+}
+
+type TypeB implements InterfaceA {
+    name: String
+}
+
+type TypeD {
+    fancy: Boolean
+}
+
+type Query {
+    union: UnionA
+}

--- a/graphql_codegen/test/assets/possible_types_map/schema.graphql.dart
+++ b/graphql_codegen/test/assets/possible_types_map/schema.graphql.dart
@@ -1,0 +1,5 @@
+const POSSIBLE_TYPES_MAP = const {
+  'UnionA': {'TypeA', 'TypeB', 'TypeC'},
+  'UnionB': {'TypeA', 'TypeB', 'TypeC', 'TypeD'},
+  'InterfaceA': {'TypeA', 'TypeB'}
+};


### PR DESCRIPTION
Possible types should be a mapping from abstract to concrete types. This requires us to resolve e.g. union of abstract types recursively.