### PR TITLE
codegen: generalize the find *.graphql file in all the root directory

### DIFF
--- a/graphql_codegen/lib/builder.dart
+++ b/graphql_codegen/lib/builder.dart
@@ -28,7 +28,7 @@ class GraphQLBuilder extends Builder {
     final result =
         await buildStep.fetchResource<GenerateResult<AssetId>>(Resource(
       () async {
-        final assets = buildStep.findAssets(Glob("lib/**.graphql"));
+        final assets = buildStep.findAssets(Glob("**.graphql"));
         final entries = await assets
             .asyncMap(
               (event) async => MapEntry(


### PR DESCRIPTION
This is useful when you are writing an API and you want to test the API with an autogenerated Query.

P.S: Not user if use `/**.graphql` or `**.graphql` only

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>