### PR TITLE
feat: exclude typename

### DIFF
--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.5.0-alpha.5
+
+* Allow excluding selection-sets from getting added `__typename`.
+
+
 # 0.5.0-alpha.4
 
 * Allow for customisable asset path through the `assetPath` config option.

--- a/packages/graphql_codegen/README.md
+++ b/packages/graphql_codegen/README.md
@@ -322,3 +322,102 @@ class PersonWidget extends StatelessWidget {
 
 }
 ```
+
+## Add typename
+
+Per default, the `addTypename` option is enabled. This'll add the `__typename` introspection field to every selection set. E.g.,
+
+```graphql 
+query Foo {
+  bar {
+    baz
+  }
+}
+
+```
+
+becomes
+
+```graphql
+query Foo {
+  bar {
+    baz
+    __typename
+  }
+  __typename
+}
+```
+
+This ensures best conditions for caching. 
+
+
+### Excluding some selections from adding typename.
+
+Any query, mutation, subscription, or fragment can be excluded from adding the `__typename` introspection by the `addTypenameExcludedPaths` option:
+
+Setting 
+
+```yaml
+addTypenameExcludedPaths:
+  - subscription 
+```
+or 
+```yaml
+addTypenameExcludedPaths:
+  - Foo
+```
+
+will both transform 
+
+```graphql
+
+subscription Foo {
+  bar {
+    baz
+  }
+}
+```
+
+to 
+
+```graphql
+
+subscription Foo {
+  bar { 
+    baz
+    __typename
+  }
+}
+```
+
+where
+
+```yaml
+addTypenameExcludedPaths:
+  - subscription.bar
+```
+or
+```yaml
+addTypenameExcludedPaths:
+  - subscription.*
+```
+or
+
+```yaml
+addTypenameExcludedPaths:
+  - **.bar
+```
+
+will transform to
+
+
+```graphql
+
+subscription Foo {
+  bar { 
+    baz
+    
+  }
+  __typename
+}
+```

--- a/packages/graphql_codegen/example/pubspec.lock
+++ b/packages/graphql_codegen/example/pubspec.lock
@@ -238,7 +238,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.0-alpha.4"
+    version: "0.5.0-alpha.5"
   graphql_codegen_config:
     dependency: "direct overridden"
     description:

--- a/packages/graphql_codegen/lib/src/transform/add_typename_transforming_visitor.dart
+++ b/packages/graphql_codegen/lib/src/transform/add_typename_transforming_visitor.dart
@@ -1,32 +1,119 @@
 import 'package:gql/ast.dart';
 import 'package:graphql_codegen/src/transform/transforming_visitor.dart';
 import 'package:graphql_codegen_config/config.dart';
+import 'package:path/path.dart';
 
 const _TYPENAME_FIELD = '__typename';
 
+const _MATCH_WILDCARD = '*';
+const _MATCH_DOUBLE_WILDCARD = '**';
+
 class AddTypenameTransformationVisitor extends RecursiveTransformingVisitor {
-  final GraphQLCodegenConfig config;
-  final List<String> path;
+  final Iterable<Iterable<String>> _excludedPatterns;
 
   AddTypenameTransformationVisitor({
-    required this.config,
-    this.path = const [],
-  });
+    required GraphQLCodegenConfig config,
+  }) : _excludedPatterns =
+            config.addTypenameExcludedPaths.map((e) => e.split(".")).toList();
+
+  AddTypenameTransformationVisitor._internal(this._excludedPatterns);
+
+  @override
+  OperationDefinitionNode visitOperationDefinitionNode(
+    OperationDefinitionNode node,
+  ) {
+    final Set<String> matches = Set.of([node.name?.value].whereType<String>());
+    switch (node.type) {
+      case OperationType.mutation:
+        matches.add('mutation');
+        break;
+      case OperationType.subscription:
+        matches.add('subscription');
+        break;
+      case OperationType.query:
+        matches.add('query');
+    }
+    final visitor = _matchAndSkip(matches);
+
+    return OperationDefinitionNode(
+      name: visitor.visitOne(node.name),
+      directives: visitor.visitAll(node.directives),
+      type: node.type,
+      selectionSet: visitor.visitOne(node.selectionSet),
+      variableDefinitions: visitor.visitAll(node.variableDefinitions),
+    );
+  }
+
+  @override
+  FragmentDefinitionNode visitFragmentDefinitionNode(
+    FragmentDefinitionNode node,
+  ) {
+    final visitor = _matchAndSkip(Set.of([
+      node.name.value,
+      'fragment',
+    ]));
+    return FragmentDefinitionNode(
+      name: visitor.visitOne(node.name),
+      directives: visitor.visitAll(node.directives),
+      selectionSet: visitor.visitOne(node.selectionSet),
+      typeCondition: visitor.visitOne(node.typeCondition),
+    );
+  }
+
+  @override
+  FieldNode visitFieldNode(
+    FieldNode node,
+  ) {
+    final visitor =
+        _matchAndSkip(Set.of([node.alias?.value ?? node.name.value]));
+    return FieldNode(
+      name: visitor.visitOne(node.name),
+      directives: visitor.visitAll(node.directives),
+      alias: visitor.visitOne(node.alias),
+      arguments: visitor.visitAll(node.arguments),
+      selectionSet: visitor.visitOne(node.selectionSet),
+    );
+  }
+
+  AddTypenameTransformationVisitor _matchAndSkip(Set<String> matches) {
+    final processedPatterns = _excludedPatterns
+        .expand(
+          (element) =>
+              element.isNotEmpty && element.first == _MATCH_DOUBLE_WILDCARD
+                  ? [element.skip(1), element]
+                  : [element],
+        )
+        .where(
+          (element) =>
+              element.isNotEmpty &&
+              (element.first == _MATCH_WILDCARD ||
+                  element.first == _MATCH_DOUBLE_WILDCARD ||
+                  matches.contains(element.first)),
+        )
+        .map((element) =>
+            element.isNotEmpty && element.first == _MATCH_DOUBLE_WILDCARD
+                ? element
+                : element.skip(1));
+    return AddTypenameTransformationVisitor._internal(processedPatterns);
+  }
+
+  bool get _isExcluded => _excludedPatterns.any((element) => element.isEmpty);
 
   @override
   SelectionSetNode visitSelectionSetNode(SelectionSetNode node) {
     final hasTypename = node.selections.whereType<FieldNode>().any((element) =>
         element.alias?.value == _TYPENAME_FIELD ||
         (element.alias == null && element.name.value == _TYPENAME_FIELD));
-    if (hasTypename) {
-      return super.visitSelectionSetNode(node);
+
+    var selections = List.of(node.selections);
+
+    if (!hasTypename && !_isExcluded) {
+      final newField = FieldNode(name: NameNode(value: _TYPENAME_FIELD));
+      selections.add(newField);
     }
 
-    final List<SelectionNode> newSelections = List.from(node.selections);
-    final newField = FieldNode(name: NameNode(value: _TYPENAME_FIELD));
-    newSelections.add(newField);
     return SelectionSetNode(
-      selections: super.visitAll(newSelections),
+      selections: visitAll(selections),
     );
   }
 }

--- a/packages/graphql_codegen/lib/src/transform/add_typename_transforming_visitor.dart
+++ b/packages/graphql_codegen/lib/src/transform/add_typename_transforming_visitor.dart
@@ -1,22 +1,32 @@
 import 'package:gql/ast.dart';
+import 'package:graphql_codegen/src/transform/transforming_visitor.dart';
+import 'package:graphql_codegen_config/config.dart';
 
 const _TYPENAME_FIELD = '__typename';
 
-class AddTypenameTransformationVisitor extends TransformingVisitor {
+class AddTypenameTransformationVisitor extends RecursiveTransformingVisitor {
+  final GraphQLCodegenConfig config;
+  final List<String> path;
+
+  AddTypenameTransformationVisitor({
+    required this.config,
+    this.path = const [],
+  });
+
   @override
   SelectionSetNode visitSelectionSetNode(SelectionSetNode node) {
     final hasTypename = node.selections.whereType<FieldNode>().any((element) =>
         element.alias?.value == _TYPENAME_FIELD ||
         (element.alias == null && element.name.value == _TYPENAME_FIELD));
     if (hasTypename) {
-      return node;
+      return super.visitSelectionSetNode(node);
     }
+
     final List<SelectionNode> newSelections = List.from(node.selections);
     final newField = FieldNode(name: NameNode(value: _TYPENAME_FIELD));
     newSelections.add(newField);
     return SelectionSetNode(
-      span: node.span,
-      selections: newSelections,
+      selections: super.visitAll(newSelections),
     );
   }
 }

--- a/packages/graphql_codegen/lib/src/transform/transform.dart
+++ b/packages/graphql_codegen/lib/src/transform/transform.dart
@@ -1,4 +1,5 @@
 import 'package:gql/ast.dart' as ast;
+import 'package:gql/ast.dart';
 import 'package:graphql_codegen/src/transform/add_typename_transforming_visitor.dart';
 import 'package:graphql_codegen_config/config.dart';
 
@@ -6,6 +7,8 @@ ast.DocumentNode transform(
   GraphQLCodegenConfig config,
   ast.DocumentNode node,
 ) =>
-    ast.transform(node, [
-      if (config.addTypename) AddTypenameTransformationVisitor(),
-    ]);
+    [if (config.addTypename) AddTypenameTransformationVisitor(config: config)]
+        .fold<Node>(
+      node,
+      (previousValue, element) => previousValue.accept(element),
+    ) as ast.DocumentNode;

--- a/packages/graphql_codegen/lib/src/transform/transforming_visitor.dart
+++ b/packages/graphql_codegen/lib/src/transform/transforming_visitor.dart
@@ -1,0 +1,486 @@
+import 'package:gql/ast.dart';
+
+class RecursiveTransformingVisitor extends Visitor<Node> {
+  N visitOne<N extends Node?>(
+    N node,
+  ) {
+    if (node == null) return node;
+
+    return node.accept(this) as N;
+  }
+
+  List<N> visitAll<N extends Node>(
+    List<N> nodes,
+  ) =>
+      nodes
+          .map(
+            (
+              node,
+            ) =>
+                node.accept(this),
+          )
+          .cast<N>()
+          .toList(growable: false);
+
+  @override
+  DocumentNode visitDocumentNode(
+    DocumentNode node,
+  ) {
+    return DocumentNode(
+      definitions: visitAll(node.definitions),
+    );
+  }
+
+  @override
+  ArgumentNode visitArgumentNode(
+    ArgumentNode node,
+  ) {
+    return ArgumentNode(
+      name: visitOne(node.name),
+      value: visitOne(node.value),
+    );
+  }
+
+  @override
+  BooleanValueNode visitBooleanValueNode(
+    BooleanValueNode node,
+  ) {
+    return BooleanValueNode(
+      value: node.value,
+    );
+  }
+
+  @override
+  DefaultValueNode visitDefaultValueNode(
+    DefaultValueNode node,
+  ) {
+    return DefaultValueNode(
+      value: visitOne(node.value),
+    );
+  }
+
+  @override
+  DirectiveDefinitionNode visitDirectiveDefinitionNode(
+    DirectiveDefinitionNode node,
+  ) {
+    return DirectiveDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      locations: node.locations,
+      repeatable: node.repeatable,
+      args: visitAll(node.args),
+    );
+  }
+
+  @override
+  DirectiveNode visitDirectiveNode(
+    DirectiveNode node,
+  ) {
+    return DirectiveNode(
+      arguments: visitAll(node.arguments),
+      name: visitOne(node.name),
+    );
+  }
+
+  @override
+  EnumTypeDefinitionNode visitEnumTypeDefinitionNode(
+    EnumTypeDefinitionNode node,
+  ) {
+    return EnumTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      values: visitAll(node.values),
+    );
+  }
+
+  @override
+  EnumTypeExtensionNode visitEnumTypeExtensionNode(
+    EnumTypeExtensionNode node,
+  ) {
+    return EnumTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      values: visitAll(node.values),
+    );
+  }
+
+  @override
+  EnumValueDefinitionNode visitEnumValueDefinitionNode(
+    EnumValueDefinitionNode node,
+  ) {
+    return EnumValueDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+    );
+  }
+
+  @override
+  EnumValueNode visitEnumValueNode(
+    EnumValueNode node,
+  ) {
+    return EnumValueNode(
+      name: visitOne(node.name),
+    );
+  }
+
+  @override
+  FieldDefinitionNode visitFieldDefinitionNode(
+    FieldDefinitionNode node,
+  ) {
+    return FieldDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      args: visitAll(node.args),
+      type: visitOne(node.type),
+    );
+  }
+
+  @override
+  FieldNode visitFieldNode(
+    FieldNode node,
+  ) {
+    return FieldNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      alias: visitOne(node.alias),
+      arguments: visitAll(node.arguments),
+      selectionSet: visitOne(node.selectionSet),
+    );
+  }
+
+  @override
+  FloatValueNode visitFloatValueNode(
+    FloatValueNode node,
+  ) {
+    return FloatValueNode(
+      value: node.value,
+    );
+  }
+
+  @override
+  FragmentDefinitionNode visitFragmentDefinitionNode(
+    FragmentDefinitionNode node,
+  ) {
+    return FragmentDefinitionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      selectionSet: visitOne(node.selectionSet),
+      typeCondition: visitOne(node.typeCondition),
+    );
+  }
+
+  @override
+  FragmentSpreadNode visitFragmentSpreadNode(
+    FragmentSpreadNode node,
+  ) {
+    return FragmentSpreadNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+    );
+  }
+
+  @override
+  InlineFragmentNode visitInlineFragmentNode(
+    InlineFragmentNode node,
+  ) {
+    return InlineFragmentNode(
+      directives: visitAll(node.directives),
+      selectionSet: visitOne(node.selectionSet),
+      typeCondition: visitOne(node.typeCondition),
+    );
+  }
+
+  @override
+  InputObjectTypeDefinitionNode visitInputObjectTypeDefinitionNode(
+    InputObjectTypeDefinitionNode node,
+  ) {
+    return InputObjectTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+    );
+  }
+
+  @override
+  InputObjectTypeExtensionNode visitInputObjectTypeExtensionNode(
+    InputObjectTypeExtensionNode node,
+  ) {
+    return InputObjectTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+    );
+  }
+
+  @override
+  InputValueDefinitionNode visitInputValueDefinitionNode(
+    InputValueDefinitionNode node,
+  ) {
+    return InputValueDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      defaultValue: visitOne(node.defaultValue),
+      type: visitOne(node.type),
+    );
+  }
+
+  @override
+  IntValueNode visitIntValueNode(
+    IntValueNode node,
+  ) {
+    return IntValueNode(
+      value: node.value,
+    );
+  }
+
+  @override
+  InterfaceTypeDefinitionNode visitInterfaceTypeDefinitionNode(
+    InterfaceTypeDefinitionNode node,
+  ) {
+    return InterfaceTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+    );
+  }
+
+  @override
+  InterfaceTypeExtensionNode visitInterfaceTypeExtensionNode(
+    InterfaceTypeExtensionNode node,
+  ) {
+    return InterfaceTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+    );
+  }
+
+  @override
+  ListTypeNode visitListTypeNode(
+    ListTypeNode node,
+  ) {
+    return ListTypeNode(
+      type: visitOne(node.type),
+      isNonNull: node.isNonNull,
+    );
+  }
+
+  @override
+  ListValueNode visitListValueNode(
+    ListValueNode node,
+  ) {
+    return ListValueNode(
+      values: visitAll(node.values),
+    );
+  }
+
+  @override
+  NameNode visitNameNode(
+    NameNode node,
+  ) {
+    return NameNode(span: node.span, value: node.value);
+  }
+
+  @override
+  NamedTypeNode visitNamedTypeNode(
+    NamedTypeNode node,
+  ) {
+    return NamedTypeNode(
+      isNonNull: node.isNonNull,
+      name: visitOne(node.name),
+    );
+  }
+
+  @override
+  NullValueNode visitNullValueNode(
+    NullValueNode node,
+  ) {
+    return NullValueNode();
+  }
+
+  @override
+  ObjectFieldNode visitObjectFieldNode(
+    ObjectFieldNode node,
+  ) {
+    return ObjectFieldNode(
+      name: visitOne(node.name),
+      value: visitOne(node.value),
+    );
+  }
+
+  @override
+  ObjectTypeDefinitionNode visitObjectTypeDefinitionNode(
+    ObjectTypeDefinitionNode node,
+  ) {
+    return ObjectTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+      interfaces: visitAll(node.interfaces),
+    );
+  }
+
+  @override
+  ObjectTypeExtensionNode visitObjectTypeExtensionNode(
+    ObjectTypeExtensionNode node,
+  ) {
+    return ObjectTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      fields: visitAll(node.fields),
+      interfaces: visitAll(node.interfaces),
+    );
+  }
+
+  @override
+  ObjectValueNode visitObjectValueNode(
+    ObjectValueNode node,
+  ) {
+    return ObjectValueNode(
+      fields: visitAll(node.fields),
+    );
+  }
+
+  @override
+  OperationDefinitionNode visitOperationDefinitionNode(
+    OperationDefinitionNode node,
+  ) {
+    return OperationDefinitionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      type: node.type,
+      selectionSet: visitOne(node.selectionSet),
+      variableDefinitions: visitAll(node.variableDefinitions),
+    );
+  }
+
+  @override
+  OperationTypeDefinitionNode visitOperationTypeDefinitionNode(
+    OperationTypeDefinitionNode node,
+  ) {
+    return OperationTypeDefinitionNode(
+      operation: node.operation,
+      type: visitOne(node.type),
+    );
+  }
+
+  @override
+  ScalarTypeDefinitionNode visitScalarTypeDefinitionNode(
+    ScalarTypeDefinitionNode node,
+  ) {
+    return ScalarTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+    );
+  }
+
+  @override
+  ScalarTypeExtensionNode visitScalarTypeExtensionNode(
+    ScalarTypeExtensionNode node,
+  ) {
+    return ScalarTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+    );
+  }
+
+  @override
+  SchemaDefinitionNode visitSchemaDefinitionNode(
+    SchemaDefinitionNode node,
+  ) {
+    return SchemaDefinitionNode(
+      directives: visitAll(node.directives),
+      operationTypes: visitAll(node.operationTypes),
+    );
+  }
+
+  @override
+  SchemaExtensionNode visitSchemaExtensionNode(
+    SchemaExtensionNode node,
+  ) {
+    return SchemaExtensionNode(
+      directives: visitAll(node.directives),
+      operationTypes: visitAll(node.operationTypes),
+    );
+  }
+
+  @override
+  SelectionSetNode visitSelectionSetNode(
+    SelectionSetNode node,
+  ) {
+    return SelectionSetNode(
+      selections: visitAll(node.selections),
+    );
+  }
+
+  @override
+  StringValueNode visitStringValueNode(
+    StringValueNode node,
+  ) {
+    return StringValueNode(
+      isBlock: node.isBlock,
+      value: node.value,
+    );
+  }
+
+  @override
+  TypeConditionNode visitTypeConditionNode(
+    TypeConditionNode node,
+  ) {
+    return TypeConditionNode(
+      on: visitOne(node.on),
+    );
+  }
+
+  @override
+  UnionTypeDefinitionNode visitUnionTypeDefinitionNode(
+    UnionTypeDefinitionNode node,
+  ) {
+    return UnionTypeDefinitionNode(
+      name: visitOne(node.name),
+      description: visitOne(node.description),
+      directives: visitAll(node.directives),
+      types: visitAll(node.types),
+    );
+  }
+
+  @override
+  UnionTypeExtensionNode visitUnionTypeExtensionNode(
+    UnionTypeExtensionNode node,
+  ) {
+    return UnionTypeExtensionNode(
+      name: visitOne(node.name),
+      directives: visitAll(node.directives),
+      types: visitAll(node.types),
+    );
+  }
+
+  @override
+  VariableDefinitionNode visitVariableDefinitionNode(
+    VariableDefinitionNode node,
+  ) {
+    return VariableDefinitionNode(
+      directives: visitAll(node.directives),
+      defaultValue: visitOne(node.defaultValue),
+      type: visitOne(node.type),
+      variable: visitOne(node.variable),
+    );
+  }
+
+  @override
+  VariableNode visitVariableNode(
+    VariableNode node,
+  ) {
+    return VariableNode(
+      name: visitOne(node.name),
+    );
+  }
+}

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -263,9 +263,9 @@ packages:
   graphql_codegen_config:
     dependency: "direct main"
     description:
-      name: graphql_codegen_config
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../graphql_codegen_config"
+      relative: true
+    source: path
     version: "0.1.6"
   graphs:
     dependency: transitive

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -263,9 +263,9 @@ packages:
   graphql_codegen_config:
     dependency: "direct main"
     description:
-      path: "../graphql_codegen_config"
-      relative: true
-    source: path
+      name: graphql_codegen_config
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.1.6"
   graphs:
     dependency: transitive

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.5.0-alpha.4
+version: 0.5.0-alpha.5
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/graphql_codegen
 

--- a/packages/graphql_codegen/test/transform_test.dart
+++ b/packages/graphql_codegen/test/transform_test.dart
@@ -1,0 +1,278 @@
+import 'package:gql/language.dart';
+import 'package:graphql_codegen/src/transform/transform.dart';
+import 'package:graphql_codegen_config/config.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+testTransform(GraphQLCodegenConfig config, String p1, String p2) => expect(
+    printNode(transform(config, parseString(p1))),
+    equals(printNode(parseString(p2))));
+
+main() {
+  group("addTypename", () {
+    test("will add typename", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        [],
+      );
+      final doc1 = """
+      type Query {
+        test: String
+      }
+      query Foobar {
+        test
+      }
+      """;
+      final doc2 = """
+      type Query {
+        test: String
+      }
+      query Foobar {
+        test
+        __typename
+      }
+      """;
+      testTransform(config, doc1, doc2);
+    });
+    test("will not add typename", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        false,
+        "",
+        [],
+      );
+      final doc1 = """
+      type Query {
+        test: String
+      }
+      query Foobar {
+        test
+      }
+      """;
+
+      testTransform(config, doc1, doc1);
+    });
+    test("will exclude query", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['query'],
+      );
+      final doc1 = """
+      type Query {
+        test: String
+      }
+      query Foobar {
+        test
+      }
+      """;
+
+      testTransform(config, doc1, doc1);
+    });
+    test("will exclude subscription", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['subscription'],
+      );
+      final doc1 = """
+      type Subscription {
+        test: String
+      }
+      subscription Foobar {
+        test
+      }
+      """;
+
+      testTransform(config, doc1, doc1);
+    });
+    test("will exclude mutation", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['mutation'],
+      );
+      final doc1 = """
+      type Mutation {
+        test: String
+      }
+      mutation Foobar {
+        test
+      }
+      """;
+
+      testTransform(config, doc1, doc1);
+    });
+    test("will exclude named operation", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['Foobar'],
+      );
+      final doc1 = """
+      type Mutation {
+        test: String
+      }
+      mutation Foobar {
+        test
+      }
+      """;
+
+      testTransform(config, doc1, doc1);
+    });
+
+    test("will exclude sub selection", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['Foobar.test'],
+      );
+      final doc1 = """
+      query Foobar {
+        test {
+          nested_test
+        }
+      }
+      """;
+      final doc2 = """
+      query Foobar {
+        test {
+          nested_test
+        }
+        __typename
+      }
+      """;
+
+      testTransform(config, doc1, doc2);
+    });
+    test("will exclude wild card", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['Foobar.*.nested_test'],
+      );
+      final doc1 = """
+      query Foobar {
+        test {
+          nested_test {
+            lol
+          }
+        }
+        test_2 {
+          nested_test {
+            lol
+          }
+          ntested_test_2 {
+            foo
+          }
+        }
+        __typename
+        }
+      """;
+      final doc2 = """
+      query Foobar {
+        test {
+          nested_test {
+            lol
+          }
+          __typename
+        }
+        test_2 {
+          nested_test {
+            lol
+          }
+          ntested_test_2 {
+            foo
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      """;
+
+      testTransform(config, doc1, doc2);
+    });
+    test("will exclude double wild card", () {
+      final config = GraphQLCodegenConfig(
+        {},
+        {},
+        true,
+        "",
+        ['Foobar.**.lol'],
+      );
+      final doc1 = """
+      query Foobar {
+        lol {
+          ok
+        }
+        test {
+          nested_test {
+            lol {
+              ok
+            }
+          }
+        }
+        test_2 {
+          nested_test {
+            lol {
+              ok
+            }
+          }
+          ntested_test_2 {
+            foo
+          }
+        }
+        }
+      """;
+      final doc2 = """
+      query Foobar {
+        lol {
+          ok
+        }
+        test {
+          nested_test {
+            lol {
+              ok
+            }
+            __typename
+          }
+          __typename
+        }
+        test_2 {
+          nested_test {
+            lol {
+              ok
+            }
+            __typename
+          }
+          ntested_test_2 {
+            foo
+            __typename
+          }
+          __typename
+        }
+        __typename
+      }
+      """;
+
+      testTransform(config, doc1, doc2);
+    });
+  });
+}


### PR DESCRIPTION
Support excluding queries and fragments from adding typenames, e.g.:

* `subscription`: Exclude all subscriptions from getting added `__typename` to the root of the query.
* `query.test`: Exclude the selection-set under the `test` root field selection in every query.
* `query.**.test`: Excludes every selection-set directly under `test` in any query.
* `query.*.test`: Excludes any selection-set directly under `test` nested one depth of every query.