### PR TITLE
docs: Update examples to use new parser

### DIFF
--- a/packages/graphql_codegen/README.md
+++ b/packages/graphql_codegen/README.md
@@ -273,7 +273,7 @@ main () async {
             ),
         ),
     );
-    final parsedData = result.parsedBodyQueryFetchPerson;
+    final parsedData = result.parsedData;
     print(parsedData?.fetchPerson?.name);
 }
 
@@ -314,7 +314,7 @@ class PersonWidget extends StatelessWidget {
             ),
             builder: (result, {fetchMore, refetch}) {
                 return Text(
-                    result.parsedDataQueryFetchPerson?.fetchPerson?.name ?? '...loading'
+                    result.parsedData?.fetchPerson?.name ?? '...loading'
                 );
             }
         );


### PR DESCRIPTION
Update examples to use `parsedData` instead of removed parsers.