### PR TITLE
feat: Fixate equality

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -107,5 +107,7 @@ jobs:
           pub global activate melos
       - name: Bootstrap melos
         run: melos bs
-      - name: Run tests
-        run: melos run test
+      - name: Run tests dart
+        run: melos run test_dart
+      - name: Run tests flutter
+        run: melos run test_flutter

--- a/melos.yaml
+++ b/melos.yaml
@@ -5,7 +5,8 @@ packages:
   
 scripts:
   analyze: melos exec -- "dart analyze ."
-  test: melos exec --dir-exists=test -- "dart test"
+  test_dart: melos exec --ignore=*example* --dir-exists=test -- "dart test"
+  test_flutter: melos exec --scope=*example* --dir-exists=test -- "flutter test"
   build_dart:  melos exec --ignore=*example* -- "dart run build_runner build --delete-conflicting-outputs" 
   build_flutter: melos  exec --scope=*example* -- "flutter pub get && flutter pub run build_runner build --delete-conflicting-outputs"
   format: melos exec -- "dart format"

--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.6.1-beta.1
+
+* Fix: Mover `parserFn` externally
+* Fix: Fresh referene on `onCompleted`.
+
 # 0.6.0
 
 * Support `generatedFileHeader`.

--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -107,6 +107,8 @@ const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
       ])),
   FRAGMENT_PERSON_SUMMARY,
 ]);
+QueryFetchPerson _parserFnQueryFetchPerson(Map<String, dynamic> data) =>
+    QueryFetchPerson.fromJson(data);
 
 class GQLOptionsQueryFetchPerson
     extends graphql.QueryOptions<QueryFetchPerson> {
@@ -129,7 +131,7 @@ class GQLOptionsQueryFetchPerson
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_PERSON,
-            parserFn: (data) => QueryFetchPerson.fromJson(data));
+            parserFn: _parserFnQueryFetchPerson);
 }
 
 class GQLWatchOptionsQueryFetchPerson
@@ -159,7 +161,7 @@ class GQLWatchOptionsQueryFetchPerson
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchPerson.fromJson(data));
+            parserFn: _parserFnQueryFetchPerson);
 }
 
 class GQLFetchMoreOptionsQueryFetchPerson extends graphql.FetchMoreOptions {
@@ -322,6 +324,8 @@ const MUTATION_UPDATE_PERSON = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdatePerson _parserFnMutationUpdatePerson(Map<String, dynamic> data) =>
+    MutationUpdatePerson.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdatePerson = FutureOr<void> Function(
     dynamic, MutationUpdatePerson?);
 
@@ -338,7 +342,8 @@ class GQLOptionsMutationUpdatePerson
       GQLOnMutationCompletedMutationUpdatePerson? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             variables: variables.toJson(),
             operationName: operationName,
             fetchPolicy: fetchPolicy,
@@ -349,11 +354,21 @@ class GQLOptionsMutationUpdatePerson
             onCompleted: onCompleted == null
                 ? null
                 : (data) => onCompleted(data,
-                    data == null ? null : MutationUpdatePerson.fromJson(data)),
+                    data == null ? null : _parserFnMutationUpdatePerson(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_PERSON,
-            parserFn: (data) => MutationUpdatePerson.fromJson(data));
+            parserFn: _parserFnMutationUpdatePerson);
+
+  final GQLOnMutationCompletedMutationUpdatePerson? onCompletedWithParsed;
+
+  @override
+  get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdatePerson
@@ -383,7 +398,7 @@ class GQLWatchOptionsMutationUpdatePerson
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdatePerson.fromJson(data));
+            parserFn: _parserFnMutationUpdatePerson);
 }
 
 extension GQLExtensionMutationUpdatePerson on graphql.GraphQLClient {
@@ -407,7 +422,8 @@ class GQLFOptionsMutationUpdatePerson
       GQLOnMutationCompletedMutationUpdatePerson? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -417,11 +433,21 @@ class GQLFOptionsMutationUpdatePerson
             onCompleted: onCompleted == null
                 ? null
                 : (data) => onCompleted(data,
-                    data == null ? null : MutationUpdatePerson.fromJson(data)),
+                    data == null ? null : _parserFnMutationUpdatePerson(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_PERSON,
-            parserFn: (data) => MutationUpdatePerson.fromJson(data));
+            parserFn: _parserFnMutationUpdatePerson);
+
+  final GQLOnMutationCompletedMutationUpdatePerson? onCompletedWithParsed;
+
+  @override
+  get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 typedef GQLFRunMutationMutationUpdatePerson
@@ -538,6 +564,9 @@ const SUBSCRIPTION_WATCH_PERSON = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+SubscriptionWatchPerson _parserFnSubscriptionWatchPerson(
+        Map<String, dynamic> data) =>
+    SubscriptionWatchPerson.fromJson(data);
 
 class GQLOptionsSubscriptionWatchPerson
     extends graphql.SubscriptionOptions<SubscriptionWatchPerson> {
@@ -558,7 +587,7 @@ class GQLOptionsSubscriptionWatchPerson
             optimisticResult: optimisticResult,
             context: context,
             document: SUBSCRIPTION_WATCH_PERSON,
-            parserFn: (data) => SubscriptionWatchPerson.fromJson(data));
+            parserFn: _parserFnSubscriptionWatchPerson);
 }
 
 class GQLWatchOptionsSubscriptionWatchPerson
@@ -588,7 +617,7 @@ class GQLWatchOptionsSubscriptionWatchPerson
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => SubscriptionWatchPerson.fromJson(data));
+            parserFn: _parserFnSubscriptionWatchPerson);
 }
 
 class GQLFetchMoreOptionsSubscriptionWatchPerson

--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -363,7 +363,7 @@ class GQLOptionsMutationUpdatePerson
   final GQLOnMutationCompletedMutationUpdatePerson? onCompletedWithParsed;
 
   @override
-  get properties => [
+  List<Object?> get properties => [
         ...super.onCompleted == null
             ? super.properties
             : super.properties.where((property) => property != onCompleted),
@@ -442,7 +442,7 @@ class GQLFOptionsMutationUpdatePerson
   final GQLOnMutationCompletedMutationUpdatePerson? onCompletedWithParsed;
 
   @override
-  get properties => [
+  List<Object?> get properties => [
         ...super.onCompleted == null
             ? super.properties
             : super.properties.where((property) => property != onCompleted),

--- a/packages/graphql_codegen/example/pubspec.yaml
+++ b/packages/graphql_codegen/example/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
 
 dependencies:
   json_annotation: ^4.0.1
-  graphql_flutter: "^5.0.1-beta.5"
+  graphql_flutter: 5.0.1-beta.5
   flutter:
     sdk: flutter
 
@@ -16,3 +16,4 @@ dev_dependencies:
     path: "../"
   build_runner: ^2.0.3
   analyzer: ^1.7.0
+  test: ^1.17.4

--- a/packages/graphql_codegen/example/pubspec.yaml
+++ b/packages/graphql_codegen/example/pubspec.yaml
@@ -5,7 +5,7 @@ environment:
 
 dependencies:
   json_annotation: ^4.0.1
-  graphql_flutter: 5.0.1-beta.5
+  graphql_flutter: 5.0.2-beta.2
   flutter:
     sdk: flutter
 

--- a/packages/graphql_codegen/example/test/equality_test.dart
+++ b/packages/graphql_codegen/example/test/equality_test.dart
@@ -1,0 +1,29 @@
+import 'package:graphql_codegen_example/main.graphql.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('equality', () {
+    test('MutationOptions considered equal', () {
+      final o1 = GQLOptionsMutationUpdatePerson(
+        variables: VariablesMutationUpdatePerson(id: '12134'),
+      );
+      final o2 = GQLOptionsMutationUpdatePerson(
+        variables: VariablesMutationUpdatePerson(id: '12134'),
+      );
+      expect(o1, equals(o2));
+    });
+    test('MutationOptions considered equal with callback', () {
+      final callback = (_d1, _d2) {};
+      final o1 = GQLOptionsMutationUpdatePerson(
+        variables: VariablesMutationUpdatePerson(id: '12134'),
+        onCompleted: callback,
+      );
+      final o2 = GQLOptionsMutationUpdatePerson(
+        variables: VariablesMutationUpdatePerson(id: '12134'),
+        onCompleted: callback,
+      );
+      expect(o1, equals(o2));
+    });
+  });
+}

--- a/packages/graphql_codegen/lib/src/printer/utils.dart
+++ b/packages/graphql_codegen/lib/src/printer/utils.dart
@@ -53,6 +53,9 @@ String printPossibleTypesMapName() => ReCase('possibleTypesMap').constantCase;
 
 String printClassName(Name name) => _printName(name);
 
+String printParserFnName(Name name) =>
+    "_" + ReCase("parserFn${_printName(name)}").camelCase;
+
 String printVariableClassName(Name name) => "Variables${_printName(name)}";
 
 String printGraphQLClientOptionsName(Name name) =>

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -263,9 +263,9 @@ packages:
   graphql_codegen_config:
     dependency: "direct main"
     description:
-      name: graphql_codegen_config
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../graphql_codegen_config"
+      relative: true
+    source: path
     version: "0.2.0"
   graphs:
     dependency: transitive

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -259,7 +259,7 @@ packages:
       name: graphql
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.0.2-beta.2"
   graphql_codegen_config:
     dependency: "direct main"
     description:

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -263,9 +263,9 @@ packages:
   graphql_codegen_config:
     dependency: "direct main"
     description:
-      path: "../graphql_codegen_config"
-      relative: true
-    source: path
+      name: graphql_codegen_config
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.2.0"
   graphs:
     dependency: transitive

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -26,5 +26,5 @@ dev_dependencies:
   build_test: ^2.1.0
   build_runner: ^2.0.3
   json_serializable: ^4.1.2
-  graphql: ^5.0.1
+  graphql: ^5.0.2-beta.2
   json_annotation: ^4.0.1

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.6.0
+version: 0.6.1-beta.1
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -58,6 +58,8 @@ const QUERY_FETCH_S_OPTIONAL = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSOptional _parserFnQueryFetchSOptional(Map<String, dynamic> data) =>
+    QueryFetchSOptional.fromJson(data);
 
 class GQLOptionsQueryFetchSOptional
     extends graphql.QueryOptions<QueryFetchSOptional> {
@@ -80,7 +82,7 @@ class GQLOptionsQueryFetchSOptional
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_OPTIONAL,
-            parserFn: (data) => QueryFetchSOptional.fromJson(data));
+            parserFn: _parserFnQueryFetchSOptional);
 }
 
 class GQLWatchOptionsQueryFetchSOptional
@@ -110,7 +112,7 @@ class GQLWatchOptionsQueryFetchSOptional
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSOptional.fromJson(data));
+            parserFn: _parserFnQueryFetchSOptional);
 }
 
 class GQLFetchMoreOptionsQueryFetchSOptional extends graphql.FetchMoreOptions {
@@ -186,6 +188,8 @@ const QUERY_FETCH_S_REQUIRED = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSRequired _parserFnQueryFetchSRequired(Map<String, dynamic> data) =>
+    QueryFetchSRequired.fromJson(data);
 
 class GQLOptionsQueryFetchSRequired
     extends graphql.QueryOptions<QueryFetchSRequired> {
@@ -208,7 +212,7 @@ class GQLOptionsQueryFetchSRequired
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_REQUIRED,
-            parserFn: (data) => QueryFetchSRequired.fromJson(data));
+            parserFn: _parserFnQueryFetchSRequired);
 }
 
 class GQLWatchOptionsQueryFetchSRequired
@@ -238,7 +242,7 @@ class GQLWatchOptionsQueryFetchSRequired
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSRequired.fromJson(data));
+            parserFn: _parserFnQueryFetchSRequired);
 }
 
 class GQLFetchMoreOptionsQueryFetchSRequired extends graphql.FetchMoreOptions {
@@ -293,6 +297,9 @@ const QUERY_FETCH_S_NO_VARIABLES = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSNoVariables _parserFnQueryFetchSNoVariables(
+        Map<String, dynamic> data) =>
+    QueryFetchSNoVariables.fromJson(data);
 
 class GQLOptionsQueryFetchSNoVariables
     extends graphql.QueryOptions<QueryFetchSNoVariables> {
@@ -313,7 +320,7 @@ class GQLOptionsQueryFetchSNoVariables
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_NO_VARIABLES,
-            parserFn: (data) => QueryFetchSNoVariables.fromJson(data));
+            parserFn: _parserFnQueryFetchSNoVariables);
 }
 
 class GQLWatchOptionsQueryFetchSNoVariables
@@ -341,7 +348,7 @@ class GQLWatchOptionsQueryFetchSNoVariables
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSNoVariables.fromJson(data));
+            parserFn: _parserFnQueryFetchSNoVariables);
 }
 
 class GQLFetchMoreOptionsQueryFetchSNoVariables
@@ -416,6 +423,9 @@ const MUTATION_UPDATE_S_OPTIONAL = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSOptional _parserFnMutationUpdateSOptional(
+        Map<String, dynamic> data) =>
+    MutationUpdateSOptional.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSOptional = FutureOr<void> Function(
     dynamic, MutationUpdateSOptional?);
 
@@ -432,7 +442,8 @@ class GQLOptionsMutationUpdateSOptional
       GQLOnMutationCompletedMutationUpdateSOptional? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             variables: variables?.toJson() ?? {},
             operationName: operationName,
             fetchPolicy: fetchPolicy,
@@ -446,11 +457,21 @@ class GQLOptionsMutationUpdateSOptional
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSOptional.fromJson(data)),
+                        : _parserFnMutationUpdateSOptional(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_OPTIONAL,
-            parserFn: (data) => MutationUpdateSOptional.fromJson(data));
+            parserFn: _parserFnMutationUpdateSOptional);
+
+  final GQLOnMutationCompletedMutationUpdateSOptional? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSOptional
@@ -480,7 +501,7 @@ class GQLWatchOptionsMutationUpdateSOptional
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSOptional.fromJson(data));
+            parserFn: _parserFnMutationUpdateSOptional);
 }
 
 extension GQLExtensionMutationUpdateSOptional on graphql.GraphQLClient {
@@ -548,6 +569,9 @@ const MUTATION_UPDATE_S_REQUIRED = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSRequired _parserFnMutationUpdateSRequired(
+        Map<String, dynamic> data) =>
+    MutationUpdateSRequired.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSRequired = FutureOr<void> Function(
     dynamic, MutationUpdateSRequired?);
 
@@ -564,7 +588,8 @@ class GQLOptionsMutationUpdateSRequired
       GQLOnMutationCompletedMutationUpdateSRequired? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             variables: variables.toJson(),
             operationName: operationName,
             fetchPolicy: fetchPolicy,
@@ -578,11 +603,21 @@ class GQLOptionsMutationUpdateSRequired
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSRequired.fromJson(data)),
+                        : _parserFnMutationUpdateSRequired(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_REQUIRED,
-            parserFn: (data) => MutationUpdateSRequired.fromJson(data));
+            parserFn: _parserFnMutationUpdateSRequired);
+
+  final GQLOnMutationCompletedMutationUpdateSRequired? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSRequired
@@ -612,7 +647,7 @@ class GQLWatchOptionsMutationUpdateSRequired
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSRequired.fromJson(data));
+            parserFn: _parserFnMutationUpdateSRequired);
 }
 
 extension GQLExtensionMutationUpdateSRequired on graphql.GraphQLClient {
@@ -657,6 +692,9 @@ const MUTATION_UPDATE_S_NO_VARIABLES = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSNoVariables _parserFnMutationUpdateSNoVariables(
+        Map<String, dynamic> data) =>
+    MutationUpdateSNoVariables.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSNoVariables = FutureOr<void>
     Function(dynamic, MutationUpdateSNoVariables?);
 
@@ -672,7 +710,8 @@ class GQLOptionsMutationUpdateSNoVariables
       GQLOnMutationCompletedMutationUpdateSNoVariables? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -685,11 +724,21 @@ class GQLOptionsMutationUpdateSNoVariables
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSNoVariables.fromJson(data)),
+                        : _parserFnMutationUpdateSNoVariables(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_NO_VARIABLES,
-            parserFn: (data) => MutationUpdateSNoVariables.fromJson(data));
+            parserFn: _parserFnMutationUpdateSNoVariables);
+
+  final GQLOnMutationCompletedMutationUpdateSNoVariables? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSNoVariables
@@ -717,7 +766,7 @@ class GQLWatchOptionsMutationUpdateSNoVariables
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSNoVariables.fromJson(data));
+            parserFn: _parserFnMutationUpdateSNoVariables);
 }
 
 extension GQLExtensionMutationUpdateSNoVariables on graphql.GraphQLClient {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
@@ -39,6 +39,8 @@ const MUTATION_UPDATE_S_NO = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSNo _parserFnMutationUpdateSNo(Map<String, dynamic> data) =>
+    MutationUpdateSNo.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSNo = FutureOr<void> Function(
     dynamic, MutationUpdateSNo?);
 
@@ -54,7 +56,8 @@ class GQLOptionsMutationUpdateSNo
       GQLOnMutationCompletedMutationUpdateSNo? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -64,11 +67,21 @@ class GQLOptionsMutationUpdateSNo
             onCompleted: onCompleted == null
                 ? null
                 : (data) => onCompleted(data,
-                    data == null ? null : MutationUpdateSNo.fromJson(data)),
+                    data == null ? null : _parserFnMutationUpdateSNo(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_NO,
-            parserFn: (data) => MutationUpdateSNo.fromJson(data));
+            parserFn: _parserFnMutationUpdateSNo);
+
+  final GQLOnMutationCompletedMutationUpdateSNo? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSNo
@@ -96,7 +109,7 @@ class GQLWatchOptionsMutationUpdateSNo
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSNo.fromJson(data));
+            parserFn: _parserFnMutationUpdateSNo);
 }
 
 extension GQLExtensionMutationUpdateSNo on graphql.GraphQLClient {
@@ -120,7 +133,8 @@ class GQLFOptionsMutationUpdateSNo
       GQLOnMutationCompletedMutationUpdateSNo? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -130,11 +144,21 @@ class GQLFOptionsMutationUpdateSNo
             onCompleted: onCompleted == null
                 ? null
                 : (data) => onCompleted(data,
-                    data == null ? null : MutationUpdateSNo.fromJson(data)),
+                    data == null ? null : _parserFnMutationUpdateSNo(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_NO,
-            parserFn: (data) => MutationUpdateSNo.fromJson(data));
+            parserFn: _parserFnMutationUpdateSNo);
+
+  final GQLOnMutationCompletedMutationUpdateSNo? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 typedef GQLFRunMutationMutationUpdateSNo

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
@@ -62,6 +62,9 @@ const MUTATION_UPDATE_S_OPTIONAL = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSOptional _parserFnMutationUpdateSOptional(
+        Map<String, dynamic> data) =>
+    MutationUpdateSOptional.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSOptional = FutureOr<void> Function(
     dynamic, MutationUpdateSOptional?);
 
@@ -78,7 +81,8 @@ class GQLOptionsMutationUpdateSOptional
       GQLOnMutationCompletedMutationUpdateSOptional? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             variables: variables?.toJson() ?? {},
             operationName: operationName,
             fetchPolicy: fetchPolicy,
@@ -92,11 +96,21 @@ class GQLOptionsMutationUpdateSOptional
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSOptional.fromJson(data)),
+                        : _parserFnMutationUpdateSOptional(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_OPTIONAL,
-            parserFn: (data) => MutationUpdateSOptional.fromJson(data));
+            parserFn: _parserFnMutationUpdateSOptional);
+
+  final GQLOnMutationCompletedMutationUpdateSOptional? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSOptional
@@ -126,7 +140,7 @@ class GQLWatchOptionsMutationUpdateSOptional
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSOptional.fromJson(data));
+            parserFn: _parserFnMutationUpdateSOptional);
 }
 
 extension GQLExtensionMutationUpdateSOptional on graphql.GraphQLClient {
@@ -150,7 +164,8 @@ class GQLFOptionsMutationUpdateSOptional
       GQLOnMutationCompletedMutationUpdateSOptional? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -163,11 +178,21 @@ class GQLFOptionsMutationUpdateSOptional
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSOptional.fromJson(data)),
+                        : _parserFnMutationUpdateSOptional(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_OPTIONAL,
-            parserFn: (data) => MutationUpdateSOptional.fromJson(data));
+            parserFn: _parserFnMutationUpdateSOptional);
+
+  final GQLOnMutationCompletedMutationUpdateSOptional? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 typedef GQLFRunMutationMutationUpdateSOptional

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -62,6 +62,9 @@ const MUTATION_UPDATE_S_REQUIRED = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+MutationUpdateSRequired _parserFnMutationUpdateSRequired(
+        Map<String, dynamic> data) =>
+    MutationUpdateSRequired.fromJson(data);
 typedef GQLOnMutationCompletedMutationUpdateSRequired = FutureOr<void> Function(
     dynamic, MutationUpdateSRequired?);
 
@@ -78,7 +81,8 @@ class GQLOptionsMutationUpdateSRequired
       GQLOnMutationCompletedMutationUpdateSRequired? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             variables: variables.toJson(),
             operationName: operationName,
             fetchPolicy: fetchPolicy,
@@ -92,11 +96,21 @@ class GQLOptionsMutationUpdateSRequired
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSRequired.fromJson(data)),
+                        : _parserFnMutationUpdateSRequired(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_REQUIRED,
-            parserFn: (data) => MutationUpdateSRequired.fromJson(data));
+            parserFn: _parserFnMutationUpdateSRequired);
+
+  final GQLOnMutationCompletedMutationUpdateSRequired? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 class GQLWatchOptionsMutationUpdateSRequired
@@ -126,7 +140,7 @@ class GQLWatchOptionsMutationUpdateSRequired
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => MutationUpdateSRequired.fromJson(data));
+            parserFn: _parserFnMutationUpdateSRequired);
 }
 
 extension GQLExtensionMutationUpdateSRequired on graphql.GraphQLClient {
@@ -150,7 +164,8 @@ class GQLFOptionsMutationUpdateSRequired
       GQLOnMutationCompletedMutationUpdateSRequired? onCompleted,
       graphql.OnMutationUpdate? update,
       graphql.OnError? onError})
-      : super(
+      : onCompletedWithParsed = onCompleted,
+        super(
             operationName: operationName,
             fetchPolicy: fetchPolicy,
             errorPolicy: errorPolicy,
@@ -163,11 +178,21 @@ class GQLFOptionsMutationUpdateSRequired
                     data,
                     data == null
                         ? null
-                        : MutationUpdateSRequired.fromJson(data)),
+                        : _parserFnMutationUpdateSRequired(data)),
             update: update,
             onError: onError,
             document: MUTATION_UPDATE_S_REQUIRED,
-            parserFn: (data) => MutationUpdateSRequired.fromJson(data));
+            parserFn: _parserFnMutationUpdateSRequired);
+
+  final GQLOnMutationCompletedMutationUpdateSRequired? onCompletedWithParsed;
+
+  @override
+  List<Object?> get properties => [
+        ...super.onCompleted == null
+            ? super.properties
+            : super.properties.where((property) => property != onCompleted),
+        onCompletedWithParsed
+      ];
 }
 
 typedef GQLFRunMutationMutationUpdateSRequired

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -38,6 +38,9 @@ const QUERY_FETCH_S_NO_VARIABLES = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSNoVariables _parserFnQueryFetchSNoVariables(
+        Map<String, dynamic> data) =>
+    QueryFetchSNoVariables.fromJson(data);
 
 class GQLOptionsQueryFetchSNoVariables
     extends graphql.QueryOptions<QueryFetchSNoVariables> {
@@ -58,7 +61,7 @@ class GQLOptionsQueryFetchSNoVariables
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_NO_VARIABLES,
-            parserFn: (data) => QueryFetchSNoVariables.fromJson(data));
+            parserFn: _parserFnQueryFetchSNoVariables);
 }
 
 class GQLWatchOptionsQueryFetchSNoVariables
@@ -86,7 +89,7 @@ class GQLWatchOptionsQueryFetchSNoVariables
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSNoVariables.fromJson(data));
+            parserFn: _parserFnQueryFetchSNoVariables);
 }
 
 class GQLFetchMoreOptionsQueryFetchSNoVariables

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -59,6 +59,8 @@ const QUERY_FETCH_S_OPTIONAL = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSOptional _parserFnQueryFetchSOptional(Map<String, dynamic> data) =>
+    QueryFetchSOptional.fromJson(data);
 
 class GQLOptionsQueryFetchSOptional
     extends graphql.QueryOptions<QueryFetchSOptional> {
@@ -81,7 +83,7 @@ class GQLOptionsQueryFetchSOptional
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_OPTIONAL,
-            parserFn: (data) => QueryFetchSOptional.fromJson(data));
+            parserFn: _parserFnQueryFetchSOptional);
 }
 
 class GQLWatchOptionsQueryFetchSOptional
@@ -111,7 +113,7 @@ class GQLWatchOptionsQueryFetchSOptional
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSOptional.fromJson(data));
+            parserFn: _parserFnQueryFetchSOptional);
 }
 
 class GQLFetchMoreOptionsQueryFetchSOptional extends graphql.FetchMoreOptions {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -59,6 +59,8 @@ const QUERY_FETCH_S_REQUIRED = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+QueryFetchSRequired _parserFnQueryFetchSRequired(Map<String, dynamic> data) =>
+    QueryFetchSRequired.fromJson(data);
 
 class GQLOptionsQueryFetchSRequired
     extends graphql.QueryOptions<QueryFetchSRequired> {
@@ -81,7 +83,7 @@ class GQLOptionsQueryFetchSRequired
             pollInterval: pollInterval,
             context: context,
             document: QUERY_FETCH_S_REQUIRED,
-            parserFn: (data) => QueryFetchSRequired.fromJson(data));
+            parserFn: _parserFnQueryFetchSRequired);
 }
 
 class GQLWatchOptionsQueryFetchSRequired
@@ -111,7 +113,7 @@ class GQLWatchOptionsQueryFetchSRequired
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => QueryFetchSRequired.fromJson(data));
+            parserFn: _parserFnQueryFetchSRequired);
 }
 
 class GQLFetchMoreOptionsQueryFetchSRequired extends graphql.FetchMoreOptions {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -54,6 +54,8 @@ const SUBSCRIPTION_NO_ARGS = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+SubscriptionNoArgs _parserFnSubscriptionNoArgs(Map<String, dynamic> data) =>
+    SubscriptionNoArgs.fromJson(data);
 
 class GQLOptionsSubscriptionNoArgs
     extends graphql.SubscriptionOptions<SubscriptionNoArgs> {
@@ -72,7 +74,7 @@ class GQLOptionsSubscriptionNoArgs
             optimisticResult: optimisticResult,
             context: context,
             document: SUBSCRIPTION_NO_ARGS,
-            parserFn: (data) => SubscriptionNoArgs.fromJson(data));
+            parserFn: _parserFnSubscriptionNoArgs);
 }
 
 class GQLWatchOptionsSubscriptionNoArgs
@@ -100,7 +102,7 @@ class GQLWatchOptionsSubscriptionNoArgs
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => SubscriptionNoArgs.fromJson(data));
+            parserFn: _parserFnSubscriptionNoArgs);
 }
 
 class GQLFetchMoreOptionsSubscriptionNoArgs extends graphql.FetchMoreOptions {
@@ -224,6 +226,9 @@ const SUBSCRIPTION_REQUIRED_ARG = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+SubscriptionRequiredArg _parserFnSubscriptionRequiredArg(
+        Map<String, dynamic> data) =>
+    SubscriptionRequiredArg.fromJson(data);
 
 class GQLOptionsSubscriptionRequiredArg
     extends graphql.SubscriptionOptions<SubscriptionRequiredArg> {
@@ -244,7 +249,7 @@ class GQLOptionsSubscriptionRequiredArg
             optimisticResult: optimisticResult,
             context: context,
             document: SUBSCRIPTION_REQUIRED_ARG,
-            parserFn: (data) => SubscriptionRequiredArg.fromJson(data));
+            parserFn: _parserFnSubscriptionRequiredArg);
 }
 
 class GQLWatchOptionsSubscriptionRequiredArg
@@ -274,7 +279,7 @@ class GQLWatchOptionsSubscriptionRequiredArg
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => SubscriptionRequiredArg.fromJson(data));
+            parserFn: _parserFnSubscriptionRequiredArg);
 }
 
 class GQLFetchMoreOptionsSubscriptionRequiredArg
@@ -404,6 +409,9 @@ const SUBSCRIPTION_OPTIONAL_ARG = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
 ]);
+SubscriptionOptionalArg _parserFnSubscriptionOptionalArg(
+        Map<String, dynamic> data) =>
+    SubscriptionOptionalArg.fromJson(data);
 
 class GQLOptionsSubscriptionOptionalArg
     extends graphql.SubscriptionOptions<SubscriptionOptionalArg> {
@@ -424,7 +432,7 @@ class GQLOptionsSubscriptionOptionalArg
             optimisticResult: optimisticResult,
             context: context,
             document: SUBSCRIPTION_OPTIONAL_ARG,
-            parserFn: (data) => SubscriptionOptionalArg.fromJson(data));
+            parserFn: _parserFnSubscriptionOptionalArg);
 }
 
 class GQLWatchOptionsSubscriptionOptionalArg
@@ -454,7 +462,7 @@ class GQLWatchOptionsSubscriptionOptionalArg
             eagerlyFetchResults: eagerlyFetchResults,
             carryForwardDataOnException: carryForwardDataOnException,
             fetchResults: fetchResults,
-            parserFn: (data) => SubscriptionOptionalArg.fromJson(data));
+            parserFn: _parserFnSubscriptionOptionalArg);
 }
 
 class GQLFetchMoreOptionsSubscriptionOptionalArg


### PR DESCRIPTION
This PR ensures that the everchanging `onCompleted` isn't considered in equality of the mutation options, it moves the `parserFn` externally to ensure that it's not triggering a re-render.


Depends on https://github.com/zino-hofmann/graphql-flutter/pull/1037