### PR TITLE
feat: Implement helpers

### DIFF
--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,4 +1,6 @@
+# 0.7.0-beta.7
 
+* Generate cache write/read methods
 * Make fragments concrete classes
 * Improve type accuracy on interfaces
 

--- a/packages/graphql_codegen/example/lib/fragments.graphql.dart
+++ b/packages/graphql_codegen/example/lib/fragments.graphql.dart
@@ -1,4 +1,5 @@
 import 'package:gql/ast.dart';
+import 'package:graphql/client.dart' as graphql;
 import 'package:graphql_codegen_example/scalars.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'fragments.graphql.g.dart';
@@ -163,6 +164,38 @@ const FRAGMENT_PERSON_SUMMARY = const FragmentDefinitionNode(
           directives: [],
           selectionSet: null)
     ]));
+
+extension ClientExtensionFragmentPersonSummary on graphql.GraphQLClient {
+  void writeFragmentPersonSummary(
+          {required FragmentPersonSummary data,
+          required Map<String, dynamic> idFields,
+          Map<String, dynamic> variables = const {},
+          broadcast = true}) =>
+      this.writeFragment(
+          graphql.FragmentRequest(
+              idFields: idFields,
+              fragment: graphql.Fragment(
+                  document: const DocumentNode(
+                      definitions: [FRAGMENT_PERSON_SUMMARY])),
+              variables: variables),
+          data: data.toJson(),
+          broadcast: broadcast);
+  FragmentPersonSummary? readFragmentPersonSummary(
+      {required Map<String, dynamic> idFields,
+      Map<String, dynamic> variables = const {},
+      optimistic = true}) {
+    final result = this.readFragment(
+        graphql.FragmentRequest(
+            idFields: idFields,
+            fragment: graphql.Fragment(
+                document:
+                    const DocumentNode(definitions: [FRAGMENT_PERSON_SUMMARY])),
+            variables: variables),
+        optimistic: optimistic);
+    return result == null ? null : FragmentPersonSummary.fromJson(result);
+  }
+}
+
 DateTime? _nullable$dateTimeFromJson(dynamic data) =>
     data == null ? null : dateTimeFromJson(data);
 dynamic _nullable$dateTimeToJson(DateTime? data) =>

--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -217,6 +217,25 @@ extension ClientExtensionQueryFetchPerson on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchPerson> watchQueryFetchPerson(
           WatchOptionsQueryFetchPerson options) =>
       this.watchQuery(options);
+  void writeQueryFetchPerson(
+          {required QueryFetchPerson data,
+          required VariablesQueryFetchPerson variables,
+          broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation: graphql.Operation(document: QUERY_FETCH_PERSON),
+              variables: variables.toJson()),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchPerson? readQueryFetchPerson(
+      {required VariablesQueryFetchPerson variables, optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_PERSON),
+            variables: variables.toJson()),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchPerson.fromJson(result);
+  }
 }
 
 graphql_flutter.QueryHookResult<QueryFetchPerson> useQueryFetchPerson(

--- a/packages/graphql_codegen/lib/src/printer/printer.dart
+++ b/packages/graphql_codegen/lib/src/printer/printer.dart
@@ -233,6 +233,8 @@ Library printRootContext<TKey>(PrintContext<ContextRoot<TKey>> c) {
             c.withContext(context),
             fragmentNode,
           ),
+        if (clients.contains(GraphQLCodegenConfigClient.graphql))
+          ...printGraphQLClientFragmentSpecs(c.withContext(context))
       ];
     }),
     ...context.contextOperations.expand((element) {

--- a/packages/graphql_codegen/lib/src/printer/utils.dart
+++ b/packages/graphql_codegen/lib/src/printer/utils.dart
@@ -111,6 +111,12 @@ String printGraphQLClientExtensionMethodName(Name name) =>
 String printGraphQLClientExtensionWatchMethodName(Name name) =>
     ReCase("Watch${_printName(name, isAction: false)}").camelCase;
 
+String printGraphQLClientExtensionWriteQueryMethodName(Name name) =>
+    ReCase("write${_printName(name, isAction: false)}").camelCase;
+
+String printGraphQLClientExtensionReadQueryMethodName(Name name) =>
+    ReCase("read${_printName(name, isAction: false)}").camelCase;
+
 String printGraphQLClientResultExtensionGetterName(Name name) =>
     ReCase("parsedData" + _printName(name)).camelCase;
 

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.7.0-beta.6
+version: 0.7.0-beta.7
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql
@@ -6,6 +6,14 @@ type Mutation {
   s(name: String): String
 }
 
+fragment NoVariables on Query {
+  s(name: "name")
+}
+
+fragment WithVariables on Query {
+  s(name: $name)
+}
+
 query FetchSOptional($name: String) {
   s(name: $name)
 }

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -5,6 +5,162 @@ import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
 @JsonSerializable()
+class FragmentNoVariables extends JsonSerializable {
+  FragmentNoVariables({this.s});
+
+  @override
+  factory FragmentNoVariables.fromJson(Map<String, dynamic> json) =>
+      _$FragmentNoVariablesFromJson(json);
+
+  final String? s;
+
+  @override
+  Map<String, dynamic> toJson() => _$FragmentNoVariablesToJson(this);
+  int get hashCode {
+    final l$s = s;
+    return Object.hashAll([l$s]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is FragmentNoVariables) || runtimeType != other.runtimeType)
+      return false;
+    final l$s = s;
+    final lOther$s = other.s;
+    if (l$s != lOther$s) return false;
+    return true;
+  }
+}
+
+const FRAGMENT_NO_VARIABLES = const FragmentDefinitionNode(
+    name: NameNode(value: 'NoVariables'),
+    typeCondition: TypeConditionNode(
+        on: NamedTypeNode(name: NameNode(value: 'Query'), isNonNull: false)),
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+          name: NameNode(value: 's'),
+          alias: null,
+          arguments: [
+            ArgumentNode(
+                name: NameNode(value: 'name'),
+                value: StringValueNode(value: 'name', isBlock: false))
+          ],
+          directives: [],
+          selectionSet: null)
+    ]));
+
+extension ClientExtensionFragmentNoVariables on graphql.GraphQLClient {
+  void writeFragmentNoVariables(
+          {required FragmentNoVariables data,
+          required Map<String, dynamic> idFields,
+          Map<String, dynamic> variables = const {},
+          broadcast = true}) =>
+      this.writeFragment(
+          graphql.FragmentRequest(
+              idFields: idFields,
+              fragment: graphql.Fragment(
+                  document:
+                      const DocumentNode(definitions: [FRAGMENT_NO_VARIABLES])),
+              variables: variables),
+          data: data.toJson(),
+          broadcast: broadcast);
+  FragmentNoVariables? readFragmentNoVariables(
+      {required Map<String, dynamic> idFields,
+      Map<String, dynamic> variables = const {},
+      optimistic = true}) {
+    final result = this.readFragment(
+        graphql.FragmentRequest(
+            idFields: idFields,
+            fragment: graphql.Fragment(
+                document:
+                    const DocumentNode(definitions: [FRAGMENT_NO_VARIABLES])),
+            variables: variables),
+        optimistic: optimistic);
+    return result == null ? null : FragmentNoVariables.fromJson(result);
+  }
+}
+
+@JsonSerializable()
+class FragmentWithVariables extends JsonSerializable {
+  FragmentWithVariables({this.s});
+
+  @override
+  factory FragmentWithVariables.fromJson(Map<String, dynamic> json) =>
+      _$FragmentWithVariablesFromJson(json);
+
+  final String? s;
+
+  @override
+  Map<String, dynamic> toJson() => _$FragmentWithVariablesToJson(this);
+  int get hashCode {
+    final l$s = s;
+    return Object.hashAll([l$s]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is FragmentWithVariables) || runtimeType != other.runtimeType)
+      return false;
+    final l$s = s;
+    final lOther$s = other.s;
+    if (l$s != lOther$s) return false;
+    return true;
+  }
+}
+
+const FRAGMENT_WITH_VARIABLES = const FragmentDefinitionNode(
+    name: NameNode(value: 'WithVariables'),
+    typeCondition: TypeConditionNode(
+        on: NamedTypeNode(name: NameNode(value: 'Query'), isNonNull: false)),
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+          name: NameNode(value: 's'),
+          alias: null,
+          arguments: [
+            ArgumentNode(
+                name: NameNode(value: 'name'),
+                value: VariableNode(name: NameNode(value: 'name')))
+          ],
+          directives: [],
+          selectionSet: null)
+    ]));
+
+extension ClientExtensionFragmentWithVariables on graphql.GraphQLClient {
+  void writeFragmentWithVariables(
+          {required FragmentWithVariables data,
+          required Map<String, dynamic> idFields,
+          Map<String, dynamic> variables = const {},
+          broadcast = true}) =>
+      this.writeFragment(
+          graphql.FragmentRequest(
+              idFields: idFields,
+              fragment: graphql.Fragment(
+                  document: const DocumentNode(
+                      definitions: [FRAGMENT_WITH_VARIABLES])),
+              variables: variables),
+          data: data.toJson(),
+          broadcast: broadcast);
+  FragmentWithVariables? readFragmentWithVariables(
+      {required Map<String, dynamic> idFields,
+      Map<String, dynamic> variables = const {},
+      optimistic = true}) {
+    final result = this.readFragment(
+        graphql.FragmentRequest(
+            idFields: idFields,
+            fragment: graphql.Fragment(
+                document:
+                    const DocumentNode(definitions: [FRAGMENT_WITH_VARIABLES])),
+            variables: variables),
+        optimistic: optimistic);
+    return result == null ? null : FragmentWithVariables.fromJson(result);
+  }
+}
+
+@JsonSerializable()
 class VariablesQueryFetchSOptional extends JsonSerializable {
   VariablesQueryFetchSOptional({this.name});
 
@@ -162,6 +318,25 @@ extension ClientExtensionQueryFetchSOptional on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSOptional> watchQueryFetchSOptional(
           [WatchOptionsQueryFetchSOptional? options]) =>
       this.watchQuery(options ?? WatchOptionsQueryFetchSOptional());
+  void writeQueryFetchSOptional(
+          {required QueryFetchSOptional data,
+          VariablesQueryFetchSOptional? variables,
+          broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation: graphql.Operation(document: QUERY_FETCH_S_OPTIONAL),
+              variables: variables?.toJson() ?? const {}),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSOptional? readQueryFetchSOptional(
+      {VariablesQueryFetchSOptional? variables, optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_OPTIONAL),
+            variables: variables?.toJson() ?? const {}),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSOptional.fromJson(result);
+  }
 }
 
 @JsonSerializable()
@@ -322,6 +497,25 @@ extension ClientExtensionQueryFetchSRequired on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSRequired> watchQueryFetchSRequired(
           WatchOptionsQueryFetchSRequired options) =>
       this.watchQuery(options);
+  void writeQueryFetchSRequired(
+          {required QueryFetchSRequired data,
+          required VariablesQueryFetchSRequired variables,
+          broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation: graphql.Operation(document: QUERY_FETCH_S_REQUIRED),
+              variables: variables.toJson()),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSRequired? readQueryFetchSRequired(
+      {required VariablesQueryFetchSRequired variables, optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_REQUIRED),
+            variables: variables.toJson()),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSRequired.fromJson(result);
+  }
 }
 
 @JsonSerializable()
@@ -439,6 +633,21 @@ extension ClientExtensionQueryFetchSNoVariables on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSNoVariables> watchQueryFetchSNoVariables(
           [WatchOptionsQueryFetchSNoVariables? options]) =>
       this.watchQuery(options ?? WatchOptionsQueryFetchSNoVariables());
+  void writeQueryFetchSNoVariables(
+          {required QueryFetchSNoVariables data, broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation:
+                  graphql.Operation(document: QUERY_FETCH_S_NO_VARIABLES)),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSNoVariables? readQueryFetchSNoVariables({optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_NO_VARIABLES)),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSNoVariables.fromJson(result);
+  }
 }
 
 @JsonSerializable()

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.g.dart
@@ -6,6 +6,29 @@ part of 'document.graphql.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+FragmentNoVariables _$FragmentNoVariablesFromJson(Map<String, dynamic> json) =>
+    FragmentNoVariables(
+      s: json['s'] as String?,
+    );
+
+Map<String, dynamic> _$FragmentNoVariablesToJson(
+        FragmentNoVariables instance) =>
+    <String, dynamic>{
+      's': instance.s,
+    };
+
+FragmentWithVariables _$FragmentWithVariablesFromJson(
+        Map<String, dynamic> json) =>
+    FragmentWithVariables(
+      s: json['s'] as String?,
+    );
+
+Map<String, dynamic> _$FragmentWithVariablesToJson(
+        FragmentWithVariables instance) =>
+    <String, dynamic>{
+      's': instance.s,
+    };
+
 VariablesQueryFetchSOptional _$VariablesQueryFetchSOptionalFromJson(
         Map<String, dynamic> json) =>
     VariablesQueryFetchSOptional(

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -120,6 +120,21 @@ extension ClientExtensionQueryFetchSNoVariables on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSNoVariables> watchQueryFetchSNoVariables(
           [WatchOptionsQueryFetchSNoVariables? options]) =>
       this.watchQuery(options ?? WatchOptionsQueryFetchSNoVariables());
+  void writeQueryFetchSNoVariables(
+          {required QueryFetchSNoVariables data, broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation:
+                  graphql.Operation(document: QUERY_FETCH_S_NO_VARIABLES)),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSNoVariables? readQueryFetchSNoVariables({optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_NO_VARIABLES)),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSNoVariables.fromJson(result);
+  }
 }
 
 graphql_flutter.QueryHookResult<QueryFetchSNoVariables>

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -163,6 +163,25 @@ extension ClientExtensionQueryFetchSOptional on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSOptional> watchQueryFetchSOptional(
           [WatchOptionsQueryFetchSOptional? options]) =>
       this.watchQuery(options ?? WatchOptionsQueryFetchSOptional());
+  void writeQueryFetchSOptional(
+          {required QueryFetchSOptional data,
+          VariablesQueryFetchSOptional? variables,
+          broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation: graphql.Operation(document: QUERY_FETCH_S_OPTIONAL),
+              variables: variables?.toJson() ?? const {}),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSOptional? readQueryFetchSOptional(
+      {VariablesQueryFetchSOptional? variables, optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_OPTIONAL),
+            variables: variables?.toJson() ?? const {}),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSOptional.fromJson(result);
+  }
 }
 
 graphql_flutter.QueryHookResult<QueryFetchSOptional> useQueryFetchSOptional(

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -163,6 +163,25 @@ extension ClientExtensionQueryFetchSRequired on graphql.GraphQLClient {
   graphql.ObservableQuery<QueryFetchSRequired> watchQueryFetchSRequired(
           WatchOptionsQueryFetchSRequired options) =>
       this.watchQuery(options);
+  void writeQueryFetchSRequired(
+          {required QueryFetchSRequired data,
+          required VariablesQueryFetchSRequired variables,
+          broadcast = true}) =>
+      this.writeQuery(
+          graphql.Request(
+              operation: graphql.Operation(document: QUERY_FETCH_S_REQUIRED),
+              variables: variables.toJson()),
+          data: data.toJson(),
+          broadcast: broadcast);
+  QueryFetchSRequired? readQueryFetchSRequired(
+      {required VariablesQueryFetchSRequired variables, optimistic = true}) {
+    final result = this.readQuery(
+        graphql.Request(
+            operation: graphql.Operation(document: QUERY_FETCH_S_REQUIRED),
+            variables: variables.toJson()),
+        optimistic: optimistic);
+    return result == null ? null : QueryFetchSRequired.fromJson(result);
+  }
 }
 
 graphql_flutter.QueryHookResult<QueryFetchSRequired> useQueryFetchSRequired(


### PR DESCRIPTION
This PR implements `readQuery`, `writeQuery`, `readFragment`, and `writeFragment`. 

The fragment variables are not generated.