### PR TITLE
fix: Support nested fragments

### DIFF
--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,4 +1,6 @@
+# 0.7.0-beta.11
 
+* Feat: Add utility extension containing `copyWith` method.
 * Fix: Explicity call `toJson`.
 
 # 0.7.0-beta.10

--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+* Fix: Explicity call `toJson`.
+
 # 0.7.0-beta.10
 
 * Fix: Import nested fragments and create DocumentNode for fragments

--- a/packages/graphql_codegen/example/lib/fragments.graphql
+++ b/packages/graphql_codegen/example/lib/fragments.graphql
@@ -5,4 +5,12 @@ fragment PersonSummary on Person {
     dob
     events
     eventsOfEvents: events_of_events
+    parents {
+        ...PersonParent
+    }
+}
+
+
+fragment PersonParent on Person {
+    name: full_name
 }

--- a/packages/graphql_codegen/example/lib/fragments.graphql.dart
+++ b/packages/graphql_codegen/example/lib/fragments.graphql.dart
@@ -139,6 +139,26 @@ class FragmentPersonSummary extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentPersonSummary on FragmentPersonSummary {
+  FragmentPersonSummary copyWith(
+          {String? Function()? nickname,
+          String? name,
+          DateTime? Function()? dob,
+          List<DateTime?>? Function()? events,
+          List<List<DateTime?>?>? Function()? eventsOfEvents,
+          List<FragmentPersonSummary$parents>? Function()? parents,
+          String? $__typename}) =>
+      FragmentPersonSummary(
+          nickname: nickname == null ? this.nickname : nickname(),
+          name: name == null ? this.name : name,
+          dob: dob == null ? this.dob : dob(),
+          events: events == null ? this.events : events(),
+          eventsOfEvents:
+              eventsOfEvents == null ? this.eventsOfEvents : eventsOfEvents(),
+          parents: parents == null ? this.parents : parents(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_PERSON_SUMMARY =
     const FragmentDefinitionNode(
         name: NameNode(value: 'PersonSummary'),
@@ -268,6 +288,14 @@ class FragmentPersonSummary$parents extends JsonSerializable
   }
 }
 
+extension UtilityExtensionFragmentPersonSummary$parents
+    on FragmentPersonSummary$parents {
+  FragmentPersonSummary$parents copyWith({String? name, String? $__typename}) =>
+      FragmentPersonSummary$parents(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentPersonParent extends JsonSerializable {
   FragmentPersonParent({required this.name, required this.$__typename});
@@ -302,6 +330,13 @@ class FragmentPersonParent extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentPersonParent on FragmentPersonParent {
+  FragmentPersonParent copyWith({String? name, String? $__typename}) =>
+      FragmentPersonParent(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_PERSON_PARENT = const FragmentDefinitionNode(

--- a/packages/graphql_codegen/example/lib/fragments.graphql.dart
+++ b/packages/graphql_codegen/example/lib/fragments.graphql.dart
@@ -4,7 +4,7 @@ import 'package:graphql_codegen_example/scalars.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'fragments.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentPersonSummary extends JsonSerializable {
   FragmentPersonSummary(
       {this.nickname,
@@ -12,6 +12,7 @@ class FragmentPersonSummary extends JsonSerializable {
       this.dob,
       this.events,
       this.eventsOfEvents,
+      this.parents,
       required this.$__typename});
 
   @override
@@ -36,6 +37,8 @@ class FragmentPersonSummary extends JsonSerializable {
       toJson: _nullable$_list$_nullable$_list$_nullable$dateTimeToJson)
   final List<List<DateTime?>?>? eventsOfEvents;
 
+  final List<FragmentPersonSummary$parents>? parents;
+
   @JsonKey(name: '__typename')
   final String $__typename;
 
@@ -47,6 +50,7 @@ class FragmentPersonSummary extends JsonSerializable {
     final l$dob = dob;
     final l$events = events;
     final l$eventsOfEvents = eventsOfEvents;
+    final l$parents = parents;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$nickname,
@@ -57,6 +61,7 @@ class FragmentPersonSummary extends JsonSerializable {
           ? null
           : Object.hashAll(l$eventsOfEvents
               .map((v) => v == null ? null : Object.hashAll(v.map((v) => v)))),
+      l$parents == null ? null : Object.hashAll(l$parents.map((v) => v)),
       l$$__typename
     ]);
   }
@@ -114,6 +119,19 @@ class FragmentPersonSummary extends JsonSerializable {
       return false;
     }
 
+    final l$parents = parents;
+    final lOther$parents = other.parents;
+    if (l$parents != null && lOther$parents != null) {
+      if (l$parents.length != lOther$parents.length) return false;
+      for (int i = 0; i < l$parents.length; i++) {
+        final l$parents$entry = l$parents[i];
+        final lOther$parents$entry = lOther$parents[i];
+        if (l$parents$entry != lOther$parents$entry) return false;
+      }
+    } else if (l$parents != lOther$parents) {
+      return false;
+    }
+
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
     if (l$$__typename != lOther$$__typename) return false;
@@ -160,6 +178,21 @@ const FRAGMENT_DEFINITION_FRAGMENT_PERSON_SUMMARY =
               directives: [],
               selectionSet: null),
           FieldNode(
+              name: NameNode(value: 'parents'),
+              alias: null,
+              arguments: [],
+              directives: [],
+              selectionSet: SelectionSetNode(selections: [
+                FragmentSpreadNode(
+                    name: NameNode(value: 'PersonParent'), directives: []),
+                FieldNode(
+                    name: NameNode(value: '__typename'),
+                    alias: null,
+                    arguments: [],
+                    directives: [],
+                    selectionSet: null)
+              ])),
+          FieldNode(
               name: NameNode(value: '__typename'),
               alias: null,
               arguments: [],
@@ -168,6 +201,7 @@ const FRAGMENT_DEFINITION_FRAGMENT_PERSON_SUMMARY =
         ]));
 const FRAGMENT_PERSON_SUMMARY = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_PERSON_SUMMARY,
+  FRAGMENT_DEFINITION_FRAGMENT_PERSON_PARENT,
 ]);
 
 extension ClientExtensionFragmentPersonSummary on graphql.GraphQLClient {
@@ -193,6 +227,129 @@ extension ClientExtensionFragmentPersonSummary on graphql.GraphQLClient {
                 document: FRAGMENT_PERSON_SUMMARY)),
         optimistic: optimistic);
     return result == null ? null : FragmentPersonSummary.fromJson(result);
+  }
+}
+
+@JsonSerializable(explicitToJson: true)
+class FragmentPersonSummary$parents extends JsonSerializable
+    implements FragmentPersonParent {
+  FragmentPersonSummary$parents(
+      {required this.name, required this.$__typename});
+
+  @override
+  factory FragmentPersonSummary$parents.fromJson(Map<String, dynamic> json) =>
+      _$FragmentPersonSummary$parentsFromJson(json);
+
+  final String name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  @override
+  Map<String, dynamic> toJson() => _$FragmentPersonSummary$parentsToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is FragmentPersonSummary$parents) ||
+        runtimeType != other.runtimeType) return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    return true;
+  }
+}
+
+@JsonSerializable(explicitToJson: true)
+class FragmentPersonParent extends JsonSerializable {
+  FragmentPersonParent({required this.name, required this.$__typename});
+
+  @override
+  factory FragmentPersonParent.fromJson(Map<String, dynamic> json) =>
+      _$FragmentPersonParentFromJson(json);
+
+  final String name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  @override
+  Map<String, dynamic> toJson() => _$FragmentPersonParentToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is FragmentPersonParent) || runtimeType != other.runtimeType)
+      return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    return true;
+  }
+}
+
+const FRAGMENT_DEFINITION_FRAGMENT_PERSON_PARENT = const FragmentDefinitionNode(
+    name: NameNode(value: 'PersonParent'),
+    typeCondition: TypeConditionNode(
+        on: NamedTypeNode(name: NameNode(value: 'Person'), isNonNull: false)),
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+          name: NameNode(value: 'full_name'),
+          alias: NameNode(value: 'name'),
+          arguments: [],
+          directives: [],
+          selectionSet: null),
+      FieldNode(
+          name: NameNode(value: '__typename'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null)
+    ]));
+const FRAGMENT_PERSON_PARENT = const DocumentNode(definitions: [
+  FRAGMENT_DEFINITION_FRAGMENT_PERSON_PARENT,
+]);
+
+extension ClientExtensionFragmentPersonParent on graphql.GraphQLClient {
+  void writeFragmentPersonParent(
+          {required FragmentPersonParent data,
+          required Map<String, dynamic> idFields,
+          broadcast = true}) =>
+      this.writeFragment(
+          graphql.FragmentRequest(
+              idFields: idFields,
+              fragment: const graphql.Fragment(
+                  fragmentName: 'PersonParent',
+                  document: FRAGMENT_PERSON_PARENT)),
+          data: data.toJson(),
+          broadcast: broadcast);
+  FragmentPersonParent? readFragmentPersonParent(
+      {required Map<String, dynamic> idFields, optimistic = true}) {
+    final result = this.readFragment(
+        graphql.FragmentRequest(
+            idFields: idFields,
+            fragment: const graphql.Fragment(
+                fragmentName: 'PersonParent',
+                document: FRAGMENT_PERSON_PARENT)),
+        optimistic: optimistic);
+    return result == null ? null : FragmentPersonParent.fromJson(result);
   }
 }
 

--- a/packages/graphql_codegen/example/lib/fragments.graphql.g.dart
+++ b/packages/graphql_codegen/example/lib/fragments.graphql.g.dart
@@ -16,6 +16,10 @@ FragmentPersonSummary _$FragmentPersonSummaryFromJson(
       eventsOfEvents:
           _nullable$_list$_nullable$_list$_nullable$dateTimeFromJson(
               json['eventsOfEvents']),
+      parents: (json['parents'] as List<dynamic>?)
+          ?.map((e) =>
+              FragmentPersonSummary$parents.fromJson(e as Map<String, dynamic>))
+          .toList(),
       $__typename: json['__typename'] as String,
     );
 
@@ -29,5 +33,34 @@ Map<String, dynamic> _$FragmentPersonSummaryToJson(
       'eventsOfEvents':
           _nullable$_list$_nullable$_list$_nullable$dateTimeToJson(
               instance.eventsOfEvents),
+      'parents': instance.parents?.map((e) => e.toJson()).toList(),
+      '__typename': instance.$__typename,
+    };
+
+FragmentPersonSummary$parents _$FragmentPersonSummary$parentsFromJson(
+        Map<String, dynamic> json) =>
+    FragmentPersonSummary$parents(
+      name: json['name'] as String,
+      $__typename: json['__typename'] as String,
+    );
+
+Map<String, dynamic> _$FragmentPersonSummary$parentsToJson(
+        FragmentPersonSummary$parents instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      '__typename': instance.$__typename,
+    };
+
+FragmentPersonParent _$FragmentPersonParentFromJson(
+        Map<String, dynamic> json) =>
+    FragmentPersonParent(
+      name: json['name'] as String,
+      $__typename: json['__typename'] as String,
+    );
+
+Map<String, dynamic> _$FragmentPersonParentToJson(
+        FragmentPersonParent instance) =>
+    <String, dynamic>{
+      'name': instance.name,
       '__typename': instance.$__typename,
     };

--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -73,6 +73,15 @@ class QueryFetchPerson extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchPerson on QueryFetchPerson {
+  QueryFetchPerson copyWith(
+          {QueryFetchPerson$fetchPerson? Function()? fetchPerson,
+          String? $__typename}) =>
+      QueryFetchPerson(
+          fetchPerson: fetchPerson == null ? this.fetchPerson : fetchPerson(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -408,6 +417,29 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetchPerson$fetchPerson
+    on QueryFetchPerson$fetchPerson {
+  QueryFetchPerson$fetchPerson copyWith(
+          {String? Function()? nickname,
+          String? name,
+          DateTime? Function()? dob,
+          List<DateTime?>? Function()? events,
+          List<List<DateTime?>?>? Function()? eventsOfEvents,
+          List<QueryFetchPerson$fetchPerson$parents>? Function()? parents,
+          String? $__typename,
+          List<QueryFetchPerson$fetchPerson$children>? Function()? children}) =>
+      QueryFetchPerson$fetchPerson(
+          nickname: nickname == null ? this.nickname : nickname(),
+          name: name == null ? this.name : name,
+          dob: dob == null ? this.dob : dob(),
+          events: events == null ? this.events : events(),
+          eventsOfEvents:
+              eventsOfEvents == null ? this.eventsOfEvents : eventsOfEvents(),
+          parents: parents == null ? this.parents : parents(),
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          children: children == null ? this.children : children());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
     implements
@@ -549,6 +581,28 @@ class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetchPerson$fetchPerson$parents
+    on QueryFetchPerson$fetchPerson$parents {
+  QueryFetchPerson$fetchPerson$parents copyWith(
+          {String? name,
+          String? $__typename,
+          String? Function()? nickname,
+          DateTime? Function()? dob,
+          List<DateTime?>? Function()? events,
+          List<List<DateTime?>?>? Function()? eventsOfEvents,
+          List<QueryFetchPerson$fetchPerson$parents$parents>? Function()?
+              parents}) =>
+      QueryFetchPerson$fetchPerson$parents(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          nickname: nickname == null ? this.nickname : nickname(),
+          dob: dob == null ? this.dob : dob(),
+          events: events == null ? this.events : events(),
+          eventsOfEvents:
+              eventsOfEvents == null ? this.eventsOfEvents : eventsOfEvents(),
+          parents: parents == null ? this.parents : parents());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson$parents$parents extends JsonSerializable
     implements FragmentPersonSummary$parents, FragmentPersonParent {
@@ -587,6 +641,15 @@ class QueryFetchPerson$fetchPerson$parents$parents extends JsonSerializable
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchPerson$fetchPerson$parents$parents
+    on QueryFetchPerson$fetchPerson$parents$parents {
+  QueryFetchPerson$fetchPerson$parents$parents copyWith(
+          {String? name, String? $__typename}) =>
+      QueryFetchPerson$fetchPerson$parents$parents(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -727,6 +790,28 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetchPerson$fetchPerson$children
+    on QueryFetchPerson$fetchPerson$children {
+  QueryFetchPerson$fetchPerson$children copyWith(
+          {String? Function()? nickname,
+          String? name,
+          DateTime? Function()? dob,
+          List<DateTime?>? Function()? events,
+          List<List<DateTime?>?>? Function()? eventsOfEvents,
+          List<QueryFetchPerson$fetchPerson$children$parents>? Function()?
+              parents,
+          String? $__typename}) =>
+      QueryFetchPerson$fetchPerson$children(
+          nickname: nickname == null ? this.nickname : nickname(),
+          name: name == null ? this.name : name,
+          dob: dob == null ? this.dob : dob(),
+          events: events == null ? this.events : events(),
+          eventsOfEvents:
+              eventsOfEvents == null ? this.eventsOfEvents : eventsOfEvents(),
+          parents: parents == null ? this.parents : parents(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson$children$parents extends JsonSerializable
     implements FragmentPersonSummary$parents, FragmentPersonParent {
@@ -765,6 +850,15 @@ class QueryFetchPerson$fetchPerson$children$parents extends JsonSerializable
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchPerson$fetchPerson$children$parents
+    on QueryFetchPerson$fetchPerson$children$parents {
+  QueryFetchPerson$fetchPerson$children$parents copyWith(
+          {String? name, String? $__typename}) =>
+      QueryFetchPerson$fetchPerson$children$parents(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -830,6 +924,16 @@ class MutationUpdatePerson extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionMutationUpdatePerson on MutationUpdatePerson {
+  MutationUpdatePerson copyWith(
+          {MutationUpdatePerson$updatePerson? Function()? updatePerson,
+          String? $__typename}) =>
+      MutationUpdatePerson(
+          updatePerson:
+              updatePerson == null ? this.updatePerson : updatePerson(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const MUTATION_UPDATE_PERSON = const DocumentNode(definitions: [
@@ -1088,6 +1192,15 @@ class MutationUpdatePerson$updatePerson extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionMutationUpdatePerson$updatePerson
+    on MutationUpdatePerson$updatePerson {
+  MutationUpdatePerson$updatePerson copyWith(
+          {String? full_name, String? $__typename}) =>
+      MutationUpdatePerson$updatePerson(
+          full_name: full_name == null ? this.full_name : full_name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionWatchPerson extends JsonSerializable {
   VariablesSubscriptionWatchPerson({this.id});
@@ -1153,6 +1266,15 @@ class SubscriptionWatchPerson extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionSubscriptionWatchPerson on SubscriptionWatchPerson {
+  SubscriptionWatchPerson copyWith(
+          {SubscriptionWatchPerson$watchPerson? Function()? watchPerson,
+          String? $__typename}) =>
+      SubscriptionWatchPerson(
+          watchPerson: watchPerson == null ? this.watchPerson : watchPerson(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const SUBSCRIPTION_WATCH_PERSON = const DocumentNode(definitions: [
@@ -1331,6 +1453,15 @@ class SubscriptionWatchPerson$watchPerson extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionSubscriptionWatchPerson$watchPerson
+    on SubscriptionWatchPerson$watchPerson {
+  SubscriptionWatchPerson$watchPerson copyWith(
+          {String? full_name, String? $__typename}) =>
+      SubscriptionWatchPerson$watchPerson(
+          full_name: full_name == null ? this.full_name : full_name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 DateTime? _nullable$dateTimeFromJson(dynamic data) =>

--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -8,7 +8,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'main.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryFetchPerson extends JsonSerializable {
   VariablesQueryFetchPerson({required this.id});
 
@@ -37,7 +37,7 @@ class VariablesQueryFetchPerson extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson extends JsonSerializable {
   QueryFetchPerson({this.fetchPerson, required this.$__typename});
 
@@ -143,6 +143,7 @@ const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
             selectionSet: null)
       ])),
   FRAGMENT_DEFINITION_FRAGMENT_PERSON_SUMMARY,
+  FRAGMENT_DEFINITION_FRAGMENT_PERSON_PARENT,
 ]);
 QueryFetchPerson _parserFnQueryFetchPerson(Map<String, dynamic> data) =>
     QueryFetchPerson.fromJson(data);
@@ -253,7 +254,7 @@ class QueryFetchPersonWidget extends graphql_flutter.Query<QueryFetchPerson> {
       : super(key: key, options: options, builder: builder);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson extends JsonSerializable
     implements FragmentPersonSummary {
   QueryFetchPerson$fetchPerson(
@@ -262,8 +263,8 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
       this.dob,
       this.events,
       this.eventsOfEvents,
-      required this.$__typename,
       this.parents,
+      required this.$__typename,
       this.children});
 
   @override
@@ -288,10 +289,10 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
       toJson: _nullable$_list$_nullable$_list$_nullable$dateTimeToJson)
   final List<List<DateTime?>?>? eventsOfEvents;
 
+  final List<QueryFetchPerson$fetchPerson$parents>? parents;
+
   @JsonKey(name: '__typename')
   final String $__typename;
-
-  final List<QueryFetchPerson$fetchPerson$parents>? parents;
 
   final List<QueryFetchPerson$fetchPerson$children>? children;
 
@@ -303,8 +304,8 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
     final l$dob = dob;
     final l$events = events;
     final l$eventsOfEvents = eventsOfEvents;
-    final l$$__typename = $__typename;
     final l$parents = parents;
+    final l$$__typename = $__typename;
     final l$children = children;
     return Object.hashAll([
       l$nickname,
@@ -315,8 +316,8 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
           ? null
           : Object.hashAll(l$eventsOfEvents
               .map((v) => v == null ? null : Object.hashAll(v.map((v) => v)))),
-      l$$__typename,
       l$parents == null ? null : Object.hashAll(l$parents.map((v) => v)),
+      l$$__typename,
       l$children == null ? null : Object.hashAll(l$children.map((v) => v))
     ]);
   }
@@ -374,9 +375,6 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
       return false;
     }
 
-    final l$$__typename = $__typename;
-    final lOther$$__typename = other.$__typename;
-    if (l$$__typename != lOther$$__typename) return false;
     final l$parents = parents;
     final lOther$parents = other.parents;
     if (l$parents != null && lOther$parents != null) {
@@ -390,6 +388,9 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
       return false;
     }
 
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
     final l$children = children;
     final lOther$children = other.children;
     if (l$children != null && lOther$children != null) {
@@ -407,25 +408,32 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
-    implements FragmentPersonSummary {
+    implements
+        FragmentPersonSummary$parents,
+        FragmentPersonParent,
+        FragmentPersonSummary {
   QueryFetchPerson$fetchPerson$parents(
-      {this.nickname,
-      required this.name,
+      {required this.name,
+      required this.$__typename,
+      this.nickname,
       this.dob,
       this.events,
       this.eventsOfEvents,
-      required this.$__typename});
+      this.parents});
 
   @override
   factory QueryFetchPerson$fetchPerson$parents.fromJson(
           Map<String, dynamic> json) =>
       _$QueryFetchPerson$fetchPerson$parentsFromJson(json);
 
-  final String? nickname;
-
   final String name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  final String? nickname;
 
   @JsonKey(
       fromJson: _nullable$dateTimeFromJson, toJson: _nullable$dateTimeToJson)
@@ -441,29 +449,30 @@ class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
       toJson: _nullable$_list$_nullable$_list$_nullable$dateTimeToJson)
   final List<List<DateTime?>?>? eventsOfEvents;
 
-  @JsonKey(name: '__typename')
-  final String $__typename;
+  final List<QueryFetchPerson$fetchPerson$parents$parents>? parents;
 
   @override
   Map<String, dynamic> toJson() =>
       _$QueryFetchPerson$fetchPerson$parentsToJson(this);
   int get hashCode {
-    final l$nickname = nickname;
     final l$name = name;
+    final l$$__typename = $__typename;
+    final l$nickname = nickname;
     final l$dob = dob;
     final l$events = events;
     final l$eventsOfEvents = eventsOfEvents;
-    final l$$__typename = $__typename;
+    final l$parents = parents;
     return Object.hashAll([
-      l$nickname,
       l$name,
+      l$$__typename,
+      l$nickname,
       l$dob,
       l$events == null ? null : Object.hashAll(l$events.map((v) => v)),
       l$eventsOfEvents == null
           ? null
           : Object.hashAll(l$eventsOfEvents
               .map((v) => v == null ? null : Object.hashAll(v.map((v) => v)))),
-      l$$__typename
+      l$parents == null ? null : Object.hashAll(l$parents.map((v) => v))
     ]);
   }
 
@@ -472,12 +481,15 @@ class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
     if (identical(this, other)) return true;
     if (!(other is QueryFetchPerson$fetchPerson$parents) ||
         runtimeType != other.runtimeType) return false;
-    final l$nickname = nickname;
-    final lOther$nickname = other.nickname;
-    if (l$nickname != lOther$nickname) return false;
     final l$name = name;
     final lOther$name = other.name;
     if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    final l$nickname = nickname;
+    final lOther$nickname = other.nickname;
+    if (l$nickname != lOther$nickname) return false;
     final l$dob = dob;
     final lOther$dob = other.dob;
     if (l$dob != lOther$dob) return false;
@@ -520,6 +532,56 @@ class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
       return false;
     }
 
+    final l$parents = parents;
+    final lOther$parents = other.parents;
+    if (l$parents != null && lOther$parents != null) {
+      if (l$parents.length != lOther$parents.length) return false;
+      for (int i = 0; i < l$parents.length; i++) {
+        final l$parents$entry = l$parents[i];
+        final lOther$parents$entry = lOther$parents[i];
+        if (l$parents$entry != lOther$parents$entry) return false;
+      }
+    } else if (l$parents != lOther$parents) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+@JsonSerializable(explicitToJson: true)
+class QueryFetchPerson$fetchPerson$parents$parents extends JsonSerializable
+    implements FragmentPersonSummary$parents, FragmentPersonParent {
+  QueryFetchPerson$fetchPerson$parents$parents(
+      {required this.name, required this.$__typename});
+
+  @override
+  factory QueryFetchPerson$fetchPerson$parents$parents.fromJson(
+          Map<String, dynamic> json) =>
+      _$QueryFetchPerson$fetchPerson$parents$parentsFromJson(json);
+
+  final String name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  @override
+  Map<String, dynamic> toJson() =>
+      _$QueryFetchPerson$fetchPerson$parents$parentsToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is QueryFetchPerson$fetchPerson$parents$parents) ||
+        runtimeType != other.runtimeType) return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
     if (l$$__typename != lOther$$__typename) return false;
@@ -527,7 +589,7 @@ class QueryFetchPerson$fetchPerson$parents extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson$children extends JsonSerializable
     implements FragmentPersonSummary {
   QueryFetchPerson$fetchPerson$children(
@@ -536,6 +598,7 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
       this.dob,
       this.events,
       this.eventsOfEvents,
+      this.parents,
       required this.$__typename});
 
   @override
@@ -561,6 +624,8 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
       toJson: _nullable$_list$_nullable$_list$_nullable$dateTimeToJson)
   final List<List<DateTime?>?>? eventsOfEvents;
 
+  final List<QueryFetchPerson$fetchPerson$children$parents>? parents;
+
   @JsonKey(name: '__typename')
   final String $__typename;
 
@@ -573,6 +638,7 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
     final l$dob = dob;
     final l$events = events;
     final l$eventsOfEvents = eventsOfEvents;
+    final l$parents = parents;
     final l$$__typename = $__typename;
     return Object.hashAll([
       l$nickname,
@@ -583,6 +649,7 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
           ? null
           : Object.hashAll(l$eventsOfEvents
               .map((v) => v == null ? null : Object.hashAll(v.map((v) => v)))),
+      l$parents == null ? null : Object.hashAll(l$parents.map((v) => v)),
       l$$__typename
     ]);
   }
@@ -640,6 +707,19 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
       return false;
     }
 
+    final l$parents = parents;
+    final lOther$parents = other.parents;
+    if (l$parents != null && lOther$parents != null) {
+      if (l$parents.length != lOther$parents.length) return false;
+      for (int i = 0; i < l$parents.length; i++) {
+        final l$parents$entry = l$parents[i];
+        final lOther$parents$entry = lOther$parents[i];
+        if (l$parents$entry != lOther$parents$entry) return false;
+      }
+    } else if (l$parents != lOther$parents) {
+      return false;
+    }
+
     final l$$__typename = $__typename;
     final lOther$$__typename = other.$__typename;
     if (l$$__typename != lOther$$__typename) return false;
@@ -647,7 +727,47 @@ class QueryFetchPerson$fetchPerson$children extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
+class QueryFetchPerson$fetchPerson$children$parents extends JsonSerializable
+    implements FragmentPersonSummary$parents, FragmentPersonParent {
+  QueryFetchPerson$fetchPerson$children$parents(
+      {required this.name, required this.$__typename});
+
+  @override
+  factory QueryFetchPerson$fetchPerson$children$parents.fromJson(
+          Map<String, dynamic> json) =>
+      _$QueryFetchPerson$fetchPerson$children$parentsFromJson(json);
+
+  final String name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  @override
+  Map<String, dynamic> toJson() =>
+      _$QueryFetchPerson$fetchPerson$children$parentsToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is QueryFetchPerson$fetchPerson$children$parents) ||
+        runtimeType != other.runtimeType) return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    return true;
+  }
+}
+
+@JsonSerializable(explicitToJson: true)
 class VariablesMutationUpdatePerson extends JsonSerializable {
   VariablesMutationUpdatePerson({required this.id});
 
@@ -676,7 +796,7 @@ class VariablesMutationUpdatePerson extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdatePerson extends JsonSerializable {
   MutationUpdatePerson({this.updatePerson, required this.$__typename});
 
@@ -929,7 +1049,7 @@ class MutationUpdatePersonWidget
                 result));
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdatePerson$updatePerson extends JsonSerializable {
   MutationUpdatePerson$updatePerson(
       {required this.full_name, required this.$__typename});
@@ -968,7 +1088,7 @@ class MutationUpdatePerson$updatePerson extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionWatchPerson extends JsonSerializable {
   VariablesSubscriptionWatchPerson({this.id});
 
@@ -999,7 +1119,7 @@ class VariablesSubscriptionWatchPerson extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionWatchPerson extends JsonSerializable {
   SubscriptionWatchPerson({this.watchPerson, required this.$__typename});
 
@@ -1174,7 +1294,7 @@ class SubscriptionWatchPersonWidget
             onSubscriptionResult: onSubscriptionResult);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionWatchPerson$watchPerson extends JsonSerializable {
   SubscriptionWatchPerson$watchPerson(
       {required this.full_name, required this.$__typename});

--- a/packages/graphql_codegen/example/lib/main.graphql.g.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.g.dart
@@ -29,7 +29,7 @@ QueryFetchPerson _$QueryFetchPersonFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchPersonToJson(QueryFetchPerson instance) =>
     <String, dynamic>{
-      'fetchPerson': instance.fetchPerson,
+      'fetchPerson': instance.fetchPerson?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -43,11 +43,11 @@ QueryFetchPerson$fetchPerson _$QueryFetchPerson$fetchPersonFromJson(
       eventsOfEvents:
           _nullable$_list$_nullable$_list$_nullable$dateTimeFromJson(
               json['eventsOfEvents']),
-      $__typename: json['__typename'] as String,
       parents: (json['parents'] as List<dynamic>?)
           ?.map((e) => QueryFetchPerson$fetchPerson$parents.fromJson(
               e as Map<String, dynamic>))
           .toList(),
+      $__typename: json['__typename'] as String,
       children: (json['children'] as List<dynamic>?)
           ?.map((e) => QueryFetchPerson$fetchPerson$children.fromJson(
               e as Map<String, dynamic>))
@@ -64,34 +64,55 @@ Map<String, dynamic> _$QueryFetchPerson$fetchPersonToJson(
       'eventsOfEvents':
           _nullable$_list$_nullable$_list$_nullable$dateTimeToJson(
               instance.eventsOfEvents),
+      'parents': instance.parents?.map((e) => e.toJson()).toList(),
       '__typename': instance.$__typename,
-      'parents': instance.parents,
-      'children': instance.children,
+      'children': instance.children?.map((e) => e.toJson()).toList(),
     };
 
 QueryFetchPerson$fetchPerson$parents
     _$QueryFetchPerson$fetchPerson$parentsFromJson(Map<String, dynamic> json) =>
         QueryFetchPerson$fetchPerson$parents(
-          nickname: json['nickname'] as String?,
           name: json['name'] as String,
+          $__typename: json['__typename'] as String,
+          nickname: json['nickname'] as String?,
           dob: _nullable$dateTimeFromJson(json['dob']),
           events: _nullable$_list$_nullable$dateTimeFromJson(json['events']),
           eventsOfEvents:
               _nullable$_list$_nullable$_list$_nullable$dateTimeFromJson(
                   json['eventsOfEvents']),
-          $__typename: json['__typename'] as String,
+          parents: (json['parents'] as List<dynamic>?)
+              ?.map((e) =>
+                  QueryFetchPerson$fetchPerson$parents$parents.fromJson(
+                      e as Map<String, dynamic>))
+              .toList(),
         );
 
 Map<String, dynamic> _$QueryFetchPerson$fetchPerson$parentsToJson(
         QueryFetchPerson$fetchPerson$parents instance) =>
     <String, dynamic>{
-      'nickname': instance.nickname,
       'name': instance.name,
+      '__typename': instance.$__typename,
+      'nickname': instance.nickname,
       'dob': _nullable$dateTimeToJson(instance.dob),
       'events': _nullable$_list$_nullable$dateTimeToJson(instance.events),
       'eventsOfEvents':
           _nullable$_list$_nullable$_list$_nullable$dateTimeToJson(
               instance.eventsOfEvents),
+      'parents': instance.parents?.map((e) => e.toJson()).toList(),
+    };
+
+QueryFetchPerson$fetchPerson$parents$parents
+    _$QueryFetchPerson$fetchPerson$parents$parentsFromJson(
+            Map<String, dynamic> json) =>
+        QueryFetchPerson$fetchPerson$parents$parents(
+          name: json['name'] as String,
+          $__typename: json['__typename'] as String,
+        );
+
+Map<String, dynamic> _$QueryFetchPerson$fetchPerson$parents$parentsToJson(
+        QueryFetchPerson$fetchPerson$parents$parents instance) =>
+    <String, dynamic>{
+      'name': instance.name,
       '__typename': instance.$__typename,
     };
 
@@ -106,6 +127,11 @@ QueryFetchPerson$fetchPerson$children
           eventsOfEvents:
               _nullable$_list$_nullable$_list$_nullable$dateTimeFromJson(
                   json['eventsOfEvents']),
+          parents: (json['parents'] as List<dynamic>?)
+              ?.map((e) =>
+                  QueryFetchPerson$fetchPerson$children$parents.fromJson(
+                      e as Map<String, dynamic>))
+              .toList(),
           $__typename: json['__typename'] as String,
         );
 
@@ -119,6 +145,22 @@ Map<String, dynamic> _$QueryFetchPerson$fetchPerson$childrenToJson(
       'eventsOfEvents':
           _nullable$_list$_nullable$_list$_nullable$dateTimeToJson(
               instance.eventsOfEvents),
+      'parents': instance.parents?.map((e) => e.toJson()).toList(),
+      '__typename': instance.$__typename,
+    };
+
+QueryFetchPerson$fetchPerson$children$parents
+    _$QueryFetchPerson$fetchPerson$children$parentsFromJson(
+            Map<String, dynamic> json) =>
+        QueryFetchPerson$fetchPerson$children$parents(
+          name: json['name'] as String,
+          $__typename: json['__typename'] as String,
+        );
+
+Map<String, dynamic> _$QueryFetchPerson$fetchPerson$children$parentsToJson(
+        QueryFetchPerson$fetchPerson$children$parents instance) =>
+    <String, dynamic>{
+      'name': instance.name,
       '__typename': instance.$__typename,
     };
 
@@ -147,7 +189,7 @@ MutationUpdatePerson _$MutationUpdatePersonFromJson(
 Map<String, dynamic> _$MutationUpdatePersonToJson(
         MutationUpdatePerson instance) =>
     <String, dynamic>{
-      'updatePerson': instance.updatePerson,
+      'updatePerson': instance.updatePerson?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -190,7 +232,7 @@ SubscriptionWatchPerson _$SubscriptionWatchPersonFromJson(
 Map<String, dynamic> _$SubscriptionWatchPersonToJson(
         SubscriptionWatchPerson instance) =>
     <String, dynamic>{
-      'watchPerson': instance.watchPerson,
+      'watchPerson': instance.watchPerson?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/example/lib/schema.graphql
+++ b/packages/graphql_codegen/example/lib/schema.graphql
@@ -13,6 +13,7 @@ type Person {
     dob: ISODateTime
     events: [ISODateTime]
     events_of_events: [[ISODateTime]]
+    parents: [Person!]
 }
 
 scalar ISODateTime

--- a/packages/graphql_codegen/example/test/cache_access_test.dart
+++ b/packages/graphql_codegen/example/test/cache_access_test.dart
@@ -1,0 +1,38 @@
+import 'package:graphql_codegen_example/fragments.graphql.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+main() {
+  group("Serialize fragments", () {
+    test("Can serialize nested fragments", () {
+      final fragment = FragmentPersonSummary(
+        $__typename: "Person",
+        name: "Lars",
+        parents: [
+          FragmentPersonSummary$parents(
+            name: "Father",
+            $__typename: "Person",
+          ),
+          FragmentPersonSummary$parents(
+            name: "Mother",
+            $__typename: "Person",
+          ),
+        ],
+      ).toJson();
+      expect(
+          fragment,
+          equals({
+            'nickname': null,
+            'name': 'Lars',
+            'dob': null,
+            'events': null,
+            'eventsOfEvents': null,
+            'parents': [
+              {'name': 'Father', '__typename': 'Person'},
+              {'name': 'Mother', '__typename': 'Person'},
+            ],
+            '__typename': 'Person'
+          }));
+    });
+  });
+}

--- a/packages/graphql_codegen/example/test/cache_access_test.dart
+++ b/packages/graphql_codegen/example/test/cache_access_test.dart
@@ -34,5 +34,35 @@ main() {
             '__typename': 'Person'
           }));
     });
+    test("Can mutate fragments", () {
+      final fragment = FragmentPersonSummary(
+        $__typename: "Person",
+        name: "Lars",
+        parents: [
+          FragmentPersonSummary$parents(
+            name: "Father",
+            $__typename: "Person",
+          ),
+          FragmentPersonSummary$parents(
+            name: "Mother",
+            $__typename: "Person",
+          ),
+        ],
+      );
+      expect(
+          fragment.copyWith(name: "Kurt").toJson(),
+          equals({
+            'nickname': null,
+            'name': 'Kurt',
+            'dob': null,
+            'events': null,
+            'eventsOfEvents': null,
+            'parents': [
+              {'name': 'Father', '__typename': 'Person'},
+              {'name': 'Mother', '__typename': 'Person'},
+            ],
+            '__typename': 'Person'
+          }));
+    });
   });
 }

--- a/packages/graphql_codegen/lib/src/printer/printer.dart
+++ b/packages/graphql_codegen/lib/src/printer/printer.dart
@@ -8,6 +8,7 @@ import 'package:graphql_codegen/src/printer/clients/graphql.dart';
 import 'package:graphql_codegen/src/printer/clients/graphql_flutter.dart';
 import 'package:graphql_codegen/src/context.dart';
 import 'package:gql_code_builder/src/ast.dart' as gql_builder;
+import 'package:path/path.dart';
 
 import 'context.dart';
 import 'utils.dart';
@@ -36,6 +37,12 @@ Spec printInput(PrintContext<ContextInput> context) => _printClass(
       context.context.properties,
     );
 
+Expression printJsonSerializableAnnotation() =>
+    _JSON_SERIALIZABLE_BASE_CLASS.call(
+      [],
+      {"explicitToJson": literalTrue},
+    );
+
 Spec _printClass(
   PrintContext context,
   String name,
@@ -45,9 +52,7 @@ Spec _printClass(
   context.markAsJsonSerializable();
   return Class(
     (b) => b
-      ..annotations = ListBuilder([
-        _JSON_SERIALIZABLE_BASE_CLASS.call([]),
-      ])
+      ..annotations = ListBuilder([printJsonSerializableAnnotation()])
       ..extend = _JSON_SERIALIZABLE_BASE_CLASS
       ..name = name
       ..constructors = ListBuilder([
@@ -364,9 +369,7 @@ Class printContext(PrintContext c) {
         ...context.fragments.map((e) => printClassName(e)).map(refer),
         if (extendContext != null) refer(printClassName(extendContext.path)),
       ])
-      ..annotations = ListBuilder(
-        [_JSON_SERIALIZABLE_BASE_CLASS.call([])],
-      )
+      ..annotations = ListBuilder([printJsonSerializableAnnotation()])
       ..extend = _JSON_SERIALIZABLE_BASE_CLASS
       ..constructors = ListBuilder([
         printConstructor(c, properties),

--- a/packages/graphql_codegen/lib/src/printer/utils.dart
+++ b/packages/graphql_codegen/lib/src/printer/utils.dart
@@ -55,6 +55,9 @@ String printPossibleTypesMapName() => ReCase('possibleTypesMap').constantCase;
 
 String printClassName(Name name) => _printName(name);
 
+String printClassExtensionName(Name name) =>
+    "UtilityExtension" + _printName(name);
+
 String printParserFnName(Name name) =>
     "_" + ReCase("parserFn${_printName(name)}").camelCase;
 

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.7.0-beta.10
+version: 0.7.0-beta.11
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 

--- a/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'schema.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentFReport extends JsonSerializable {
   FragmentFReport({this.title, required this.$__typename});
 
@@ -61,7 +61,7 @@ const FRAGMENT_F_REPORT = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F_REPORT,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ(
       {this.docsWithTypename,
@@ -278,7 +278,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F_REPORT,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithTypename extends JsonSerializable {
   QueryQ$docsWithTypename({required this.$__typename});
 
@@ -308,7 +308,7 @@ class QueryQ$docsWithTypename extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWihtoutTypename extends JsonSerializable {
   QueryQ$docsWihtoutTypename({this.title, required this.$__typename});
 
@@ -344,7 +344,7 @@ class QueryQ$docsWihtoutTypename extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithAliasedTypename extends JsonSerializable {
   QueryQ$docsWithAliasedTypename({this.$__typename});
 
@@ -374,7 +374,7 @@ class QueryQ$docsWithAliasedTypename extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithFragment extends JsonSerializable {
   QueryQ$docsWithFragment({required this.$__typename});
 
@@ -412,7 +412,7 @@ class QueryQ$docsWithFragment extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithFragment$Contract extends JsonSerializable
     implements QueryQ$docsWithFragment {
   QueryQ$docsWithFragment$Contract({required this.$__typename, this.title});
@@ -451,7 +451,7 @@ class QueryQ$docsWithFragment$Contract extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithFragment$Report extends JsonSerializable
     implements FragmentFReport, QueryQ$docsWithFragment {
   QueryQ$docsWithFragment$Report({required this.$__typename, this.title});

--- a/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
@@ -38,6 +38,13 @@ class FragmentFReport extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentFReport on FragmentFReport {
+  FragmentFReport copyWith({String? Function()? title, String? $__typename}) =>
+      FragmentFReport(
+          title: title == null ? this.title : title(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F_REPORT = const FragmentDefinitionNode(
     name: NameNode(value: 'FReport'),
     typeCondition: TypeConditionNode(
@@ -182,6 +189,30 @@ class QueryQ extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith(
+          {List<QueryQ$docsWithTypename?>? Function()? docsWithTypename,
+          List<QueryQ$docsWihtoutTypename?>? Function()? docsWihtoutTypename,
+          List<QueryQ$docsWithAliasedTypename?>? Function()?
+              docsWithAliasedTypename,
+          List<QueryQ$docsWithFragment?>? Function()? docsWithFragment,
+          String? $__typename}) =>
+      QueryQ(
+          docsWithTypename: docsWithTypename == null
+              ? this.docsWithTypename
+              : docsWithTypename(),
+          docsWihtoutTypename: docsWihtoutTypename == null
+              ? this.docsWihtoutTypename
+              : docsWihtoutTypename(),
+          docsWithAliasedTypename: docsWithAliasedTypename == null
+              ? this.docsWithAliasedTypename
+              : docsWithAliasedTypename(),
+          docsWithFragment: docsWithFragment == null
+              ? this.docsWithFragment
+              : docsWithFragment(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const QUERY_Q = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -308,6 +339,12 @@ class QueryQ$docsWithTypename extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryQ$docsWithTypename on QueryQ$docsWithTypename {
+  QueryQ$docsWithTypename copyWith({String? $__typename}) =>
+      QueryQ$docsWithTypename(
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$docsWihtoutTypename extends JsonSerializable {
   QueryQ$docsWihtoutTypename({this.title, required this.$__typename});
@@ -344,6 +381,15 @@ class QueryQ$docsWihtoutTypename extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryQ$docsWihtoutTypename
+    on QueryQ$docsWihtoutTypename {
+  QueryQ$docsWihtoutTypename copyWith(
+          {String? Function()? title, String? $__typename}) =>
+      QueryQ$docsWihtoutTypename(
+          title: title == null ? this.title : title(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithAliasedTypename extends JsonSerializable {
   QueryQ$docsWithAliasedTypename({this.$__typename});
@@ -372,6 +418,13 @@ class QueryQ$docsWithAliasedTypename extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$docsWithAliasedTypename
+    on QueryQ$docsWithAliasedTypename {
+  QueryQ$docsWithAliasedTypename copyWith({String? Function()? $__typename}) =>
+      QueryQ$docsWithAliasedTypename(
+          $__typename: $__typename == null ? this.$__typename : $__typename());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -410,6 +463,12 @@ class QueryQ$docsWithFragment extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$docsWithFragment on QueryQ$docsWithFragment {
+  QueryQ$docsWithFragment copyWith({String? $__typename}) =>
+      QueryQ$docsWithFragment(
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -451,6 +510,15 @@ class QueryQ$docsWithFragment$Contract extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryQ$docsWithFragment$Contract
+    on QueryQ$docsWithFragment$Contract {
+  QueryQ$docsWithFragment$Contract copyWith(
+          {String? $__typename, String? Function()? title}) =>
+      QueryQ$docsWithFragment$Contract(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          title: title == null ? this.title : title());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$docsWithFragment$Report extends JsonSerializable
     implements FragmentFReport, QueryQ$docsWithFragment {
@@ -486,6 +554,15 @@ class QueryQ$docsWithFragment$Report extends JsonSerializable
     if (l$title != lOther$title) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$docsWithFragment$Report
+    on QueryQ$docsWithFragment$Report {
+  QueryQ$docsWithFragment$Report copyWith(
+          {String? $__typename, String? Function()? title}) =>
+      QueryQ$docsWithFragment$Report(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          title: title == null ? this.title : title());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.g.dart
@@ -45,10 +45,14 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      'docsWithTypename': instance.docsWithTypename,
-      'docsWihtoutTypename': instance.docsWihtoutTypename,
-      'docsWithAliasedTypename': instance.docsWithAliasedTypename,
-      'docsWithFragment': instance.docsWithFragment,
+      'docsWithTypename':
+          instance.docsWithTypename?.map((e) => e?.toJson()).toList(),
+      'docsWihtoutTypename':
+          instance.docsWihtoutTypename?.map((e) => e?.toJson()).toList(),
+      'docsWithAliasedTypename':
+          instance.docsWithAliasedTypename?.map((e) => e?.toJson()).toList(),
+      'docsWithFragment':
+          instance.docsWithFragment?.map((e) => e?.toJson()).toList(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/enums/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/enums/query.graphql.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'schema.graphql.dart';
 part 'query.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFoobar extends JsonSerializable {
   QueryFoobar({this.field, this.fields});
 

--- a/packages/graphql_codegen/test/assets/enums/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/enums/query.graphql.dart
@@ -53,6 +53,14 @@ class QueryFoobar extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFoobar on QueryFoobar {
+  QueryFoobar copyWith(
+          {EnumEnum? Function()? field, List<EnumEnum>? Function()? fields}) =>
+      QueryFoobar(
+          field: field == null ? this.field : field(),
+          fields: fields == null ? this.fields : fields());
+}
+
 const QUERY_FOOBAR = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,

--- a/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
+++ b/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
@@ -32,6 +32,11 @@ class QueryFetchName extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchName on QueryFetchName {
+  QueryFetchName copyWith({QueryFetchName$name? Function()? name}) =>
+      QueryFetchName(name: name == null ? this.name : name());
+}
+
 const QUERY_FETCH_NAME = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -78,4 +83,9 @@ class QueryFetchName$name extends JsonSerializable implements FragmentF {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchName$name on QueryFetchName$name {
+  QueryFetchName$name copyWith({String? name}) =>
+      QueryFetchName$name(name: name == null ? this.name : name);
 }

--- a/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
+++ b/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
@@ -3,7 +3,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'a.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchName extends JsonSerializable {
   QueryFetchName({this.name});
 
@@ -51,7 +51,7 @@ const QUERY_FETCH_NAME = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchName$name extends JsonSerializable implements FragmentF {
   QueryFetchName$name({required this.name});
 

--- a/packages/graphql_codegen/test/assets/first_test/a.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/first_test/a.graphql.g.dart
@@ -15,7 +15,7 @@ QueryFetchName _$QueryFetchNameFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchNameToJson(QueryFetchName instance) =>
     <String, dynamic>{
-      'name': instance.name,
+      'name': instance.name?.toJson(),
     };
 
 QueryFetchName$name _$QueryFetchName$nameFromJson(Map<String, dynamic> json) =>

--- a/packages/graphql_codegen/test/assets/first_test/fragments.graphql.dart
+++ b/packages/graphql_codegen/test/assets/first_test/fragments.graphql.dart
@@ -30,6 +30,11 @@ class FragmentF extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF on FragmentF {
+  FragmentF copyWith({String? name}) =>
+      FragmentF(name: name == null ? this.name : name);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F = const FragmentDefinitionNode(
     name: NameNode(value: 'F'),
     typeCondition: TypeConditionNode(

--- a/packages/graphql_codegen/test/assets/first_test/fragments.graphql.dart
+++ b/packages/graphql_codegen/test/assets/first_test/fragments.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'fragments.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF extends JsonSerializable {
   FragmentF({required this.name});
 

--- a/packages/graphql_codegen/test/assets/fragment_imports/document1.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document1.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document1.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.value});
 

--- a/packages/graphql_codegen/test/assets/fragment_imports/document1.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document1.graphql.dart
@@ -31,6 +31,11 @@ class FragmentF2 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith({int? Function()? value}) =>
+      FragmentF2(value: value == null ? this.value : value());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
     name: NameNode(value: 'F2'),
     typeCondition: TypeConditionNode(

--- a/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
@@ -32,6 +32,11 @@ class FragmentF1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF1 on FragmentF1 {
+  FragmentF1 copyWith({String? Function()? name}) =>
+      FragmentF1(name: name == null ? this.name : name());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F1 = const FragmentDefinitionNode(
     name: NameNode(value: 'F1'),
     typeCondition: TypeConditionNode(
@@ -74,6 +79,11 @@ class QueryQ extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$t? Function()? t}) =>
+      QueryQ(t: t == null ? this.t : t());
 }
 
 const QUERY_Q = const DocumentNode(definitions: [
@@ -123,4 +133,9 @@ class QueryQ$t extends JsonSerializable implements FragmentF1 {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$t on QueryQ$t {
+  QueryQ$t copyWith({String? Function()? name}) =>
+      QueryQ$t(name: name == null ? this.name : name());
 }

--- a/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
@@ -3,7 +3,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document2.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1 extends JsonSerializable {
   FragmentF1({this.name});
 
@@ -49,7 +49,7 @@ const FRAGMENT_F1 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F1,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
 
@@ -97,7 +97,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t extends JsonSerializable implements FragmentF1 {
   QueryQ$t({this.name});
 

--- a/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.g.dart
@@ -22,7 +22,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(

--- a/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
@@ -31,6 +31,11 @@ class FragmentT1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentT1 on FragmentT1 {
+  FragmentT1 copyWith({FragmentT1$t? Function()? t}) =>
+      FragmentT1(t: t == null ? this.t : t());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_T1 = const FragmentDefinitionNode(
     name: NameNode(value: 'T1'),
     typeCondition: TypeConditionNode(
@@ -84,6 +89,11 @@ class FragmentT1$t extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentT1$t on FragmentT1$t {
+  FragmentT1$t copyWith({String? Function()? name}) =>
+      FragmentT1$t(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentT2 extends JsonSerializable {
   FragmentT2({this.t, this.name});
@@ -117,6 +127,13 @@ class FragmentT2 extends JsonSerializable {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentT2 on FragmentT2 {
+  FragmentT2 copyWith(
+          {FragmentT2$t? Function()? t, String? Function()? name}) =>
+      FragmentT2(
+          t: t == null ? this.t : t(), name: name == null ? this.name : name());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_T2 = const FragmentDefinitionNode(
@@ -178,6 +195,11 @@ class FragmentT2$t extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentT2$t on FragmentT2$t {
+  FragmentT2$t copyWith({String? Function()? name}) =>
+      FragmentT2$t(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentTC extends JsonSerializable implements FragmentT1, FragmentT2 {
   FragmentTC({this.t, this.name});
@@ -211,6 +233,13 @@ class FragmentTC extends JsonSerializable implements FragmentT1, FragmentT2 {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentTC on FragmentTC {
+  FragmentTC copyWith(
+          {FragmentTC$t? Function()? t, String? Function()? name}) =>
+      FragmentTC(
+          t: t == null ? this.t : t(), name: name == null ? this.name : name());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_T_C = const FragmentDefinitionNode(
@@ -258,6 +287,11 @@ class FragmentTC$t extends JsonSerializable
   }
 }
 
+extension UtilityExtensionFragmentTC$t on FragmentTC$t {
+  FragmentTC$t copyWith({String? Function()? name}) =>
+      FragmentTC$t(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
@@ -283,6 +317,11 @@ class QueryQ extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$t? Function()? t}) =>
+      QueryQ(t: t == null ? this.t : t());
 }
 
 const QUERY_Q = const DocumentNode(definitions: [
@@ -341,6 +380,12 @@ class QueryQ$t extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryQ$t on QueryQ$t {
+  QueryQ$t copyWith({QueryQ$t$t? Function()? t, String? Function()? name}) =>
+      QueryQ$t(
+          t: t == null ? this.t : t(), name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable
     implements FragmentTC$t, FragmentT1$t, FragmentT2$t {
@@ -369,6 +414,11 @@ class QueryQ$t$t extends JsonSerializable
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$t$t on QueryQ$t$t {
+  QueryQ$t$t copyWith({String? Function()? name}) =>
+      QueryQ$t$t(name: name == null ? this.name : name());
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentT1 extends JsonSerializable {
   FragmentT1({this.t});
 
@@ -55,7 +55,7 @@ const FRAGMENT_T1 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_T1,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentT1$t extends JsonSerializable {
   FragmentT1$t({this.name});
 
@@ -84,7 +84,7 @@ class FragmentT1$t extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentT2 extends JsonSerializable {
   FragmentT2({this.t, this.name});
 
@@ -149,7 +149,7 @@ const FRAGMENT_T2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_T2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentT2$t extends JsonSerializable {
   FragmentT2$t({this.name});
 
@@ -178,7 +178,7 @@ class FragmentT2$t extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentTC extends JsonSerializable implements FragmentT1, FragmentT2 {
   FragmentTC({this.t, this.name});
 
@@ -228,7 +228,7 @@ const FRAGMENT_T_C = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_T2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentTC$t extends JsonSerializable
     implements FragmentT1$t, FragmentT2$t {
   FragmentTC$t({this.name});
@@ -258,7 +258,7 @@ class FragmentTC$t extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
 
@@ -306,7 +306,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_T2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t extends JsonSerializable
     implements FragmentTC, FragmentT1, FragmentT2 {
   QueryQ$t({this.t, this.name});
@@ -341,7 +341,7 @@ class QueryQ$t extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable
     implements FragmentTC$t, FragmentT1$t, FragmentT2$t {
   QueryQ$t$t({this.name});

--- a/packages/graphql_codegen/test/assets/fragment_override/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragment_override/document.graphql.g.dart
@@ -14,7 +14,7 @@ FragmentT1 _$FragmentT1FromJson(Map<String, dynamic> json) => FragmentT1(
 
 Map<String, dynamic> _$FragmentT1ToJson(FragmentT1 instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 FragmentT1$t _$FragmentT1$tFromJson(Map<String, dynamic> json) => FragmentT1$t(
@@ -35,7 +35,7 @@ FragmentT2 _$FragmentT2FromJson(Map<String, dynamic> json) => FragmentT2(
 
 Map<String, dynamic> _$FragmentT2ToJson(FragmentT2 instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
       'name': instance.name,
     };
 
@@ -57,7 +57,7 @@ FragmentTC _$FragmentTCFromJson(Map<String, dynamic> json) => FragmentTC(
 
 Map<String, dynamic> _$FragmentTCToJson(FragmentTC instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
       'name': instance.name,
     };
 
@@ -77,7 +77,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
@@ -88,7 +88,7 @@ QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
     );
 
 Map<String, dynamic> _$QueryQ$tToJson(QueryQ$t instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
       'name': instance.name,
     };
 

--- a/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class InputInput extends JsonSerializable {
   InputInput({this.inputField});
 
@@ -31,7 +31,7 @@ class InputInput extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesFragmentF1 extends JsonSerializable {
   VariablesFragmentF1({this.i, required this.name});
 
@@ -66,7 +66,7 @@ class VariablesFragmentF1 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1 extends JsonSerializable {
   FragmentF1({this.level1, required this.$__typename});
 
@@ -181,7 +181,7 @@ const FRAGMENT_F1 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F1,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1$level1 extends JsonSerializable {
   FragmentF1$level1({this.level2, required this.$__typename});
 
@@ -217,7 +217,7 @@ class FragmentF1$level1 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1$level1$level2 extends JsonSerializable {
   FragmentF1$level1$level2({this.level3, required this.$__typename});
 
@@ -253,7 +253,7 @@ class FragmentF1$level1$level2 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1$level1$level2$level3 extends JsonSerializable {
   FragmentF1$level1$level2$level3({this.level4, required this.$__typename});
 
@@ -290,7 +290,7 @@ class FragmentF1$level1$level2$level3 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesFragmentF2 extends JsonSerializable {
   VariablesFragmentF2({this.i, this.name});
 
@@ -325,7 +325,7 @@ class VariablesFragmentF2 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.level1, required this.$__typename});
 
@@ -397,7 +397,7 @@ const FRAGMENT_F2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F21,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$level1 extends JsonSerializable implements FragmentF21 {
   FragmentF2$level1({this.level2, required this.$__typename});
 
@@ -433,7 +433,7 @@ class FragmentF2$level1 extends JsonSerializable implements FragmentF21 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$level1$level2 extends JsonSerializable
     implements FragmentF21$level2 {
   FragmentF2$level1$level2({this.level3, required this.$__typename});
@@ -470,7 +470,7 @@ class FragmentF2$level1$level2 extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$level1$level2$level3 extends JsonSerializable
     implements FragmentF21$level2$level3 {
   FragmentF2$level1$level2$level3({this.level4, required this.$__typename});
@@ -508,7 +508,7 @@ class FragmentF2$level1$level2$level3 extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesFragmentF21 extends JsonSerializable {
   VariablesFragmentF21({this.i});
 
@@ -537,7 +537,7 @@ class VariablesFragmentF21 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF21 extends JsonSerializable {
   FragmentF21({this.level2, required this.$__typename});
 
@@ -634,7 +634,7 @@ const FRAGMENT_F21 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F21,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF21$level2 extends JsonSerializable {
   FragmentF21$level2({this.level3, required this.$__typename});
 
@@ -670,7 +670,7 @@ class FragmentF21$level2 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF21$level2$level3 extends JsonSerializable {
   FragmentF21$level2$level3({this.level4, required this.$__typename});
 

--- a/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.dart
@@ -102,6 +102,14 @@ class FragmentF1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF1 on FragmentF1 {
+  FragmentF1 copyWith(
+          {FragmentF1$level1? Function()? level1, String? $__typename}) =>
+      FragmentF1(
+          level1: level1 == null ? this.level1 : level1(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F1 = const FragmentDefinitionNode(
     name: NameNode(value: 'F1'),
     typeCondition: TypeConditionNode(
@@ -217,6 +225,15 @@ class FragmentF1$level1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF1$level1 on FragmentF1$level1 {
+  FragmentF1$level1 copyWith(
+          {FragmentF1$level1$level2? Function()? level2,
+          String? $__typename}) =>
+      FragmentF1$level1(
+          level2: level2 == null ? this.level2 : level2(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF1$level1$level2 extends JsonSerializable {
   FragmentF1$level1$level2({this.level3, required this.$__typename});
@@ -251,6 +268,15 @@ class FragmentF1$level1$level2 extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF1$level1$level2 on FragmentF1$level1$level2 {
+  FragmentF1$level1$level2 copyWith(
+          {FragmentF1$level1$level2$level3? Function()? level3,
+          String? $__typename}) =>
+      FragmentF1$level1$level2(
+          level3: level3 == null ? this.level3 : level3(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -288,6 +314,15 @@ class FragmentF1$level1$level2$level3 extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF1$level1$level2$level3
+    on FragmentF1$level1$level2$level3 {
+  FragmentF1$level1$level2$level3 copyWith(
+          {int? Function()? level4, String? $__typename}) =>
+      FragmentF1$level1$level2$level3(
+          level4: level4 == null ? this.level4 : level4(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -359,6 +394,14 @@ class FragmentF2 extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith(
+          {FragmentF2$level1? Function()? level1, String? $__typename}) =>
+      FragmentF2(
+          level1: level1 == null ? this.level1 : level1(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
@@ -433,6 +476,15 @@ class FragmentF2$level1 extends JsonSerializable implements FragmentF21 {
   }
 }
 
+extension UtilityExtensionFragmentF2$level1 on FragmentF2$level1 {
+  FragmentF2$level1 copyWith(
+          {FragmentF2$level1$level2? Function()? level2,
+          String? $__typename}) =>
+      FragmentF2$level1(
+          level2: level2 == null ? this.level2 : level2(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF2$level1$level2 extends JsonSerializable
     implements FragmentF21$level2 {
@@ -468,6 +520,15 @@ class FragmentF2$level1$level2 extends JsonSerializable
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF2$level1$level2 on FragmentF2$level1$level2 {
+  FragmentF2$level1$level2 copyWith(
+          {FragmentF2$level1$level2$level3? Function()? level3,
+          String? $__typename}) =>
+      FragmentF2$level1$level2(
+          level3: level3 == null ? this.level3 : level3(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -506,6 +567,15 @@ class FragmentF2$level1$level2$level3 extends JsonSerializable
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF2$level1$level2$level3
+    on FragmentF2$level1$level2$level3 {
+  FragmentF2$level1$level2$level3 copyWith(
+          {int? Function()? level4, String? $__typename}) =>
+      FragmentF2$level1$level2$level3(
+          level4: level4 == null ? this.level4 : level4(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -571,6 +641,14 @@ class FragmentF21 extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF21 on FragmentF21 {
+  FragmentF21 copyWith(
+          {FragmentF21$level2? Function()? level2, String? $__typename}) =>
+      FragmentF21(
+          level2: level2 == null ? this.level2 : level2(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F21 = const FragmentDefinitionNode(
@@ -670,6 +748,15 @@ class FragmentF21$level2 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF21$level2 on FragmentF21$level2 {
+  FragmentF21$level2 copyWith(
+          {FragmentF21$level2$level3? Function()? level3,
+          String? $__typename}) =>
+      FragmentF21$level2(
+          level3: level3 == null ? this.level3 : level3(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF21$level2$level3 extends JsonSerializable {
   FragmentF21$level2$level3({this.level4, required this.$__typename});
@@ -704,6 +791,15 @@ class FragmentF21$level2$level3 extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF21$level2$level3
+    on FragmentF21$level2$level3 {
+  FragmentF21$level2$level3 copyWith(
+          {int? Function()? level4, String? $__typename}) =>
+      FragmentF21$level2$level3(
+          level4: level4 == null ? this.level4 : level4(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables/document.graphql.g.dart
@@ -37,7 +37,7 @@ FragmentF1 _$FragmentF1FromJson(Map<String, dynamic> json) => FragmentF1(
 
 Map<String, dynamic> _$FragmentF1ToJson(FragmentF1 instance) =>
     <String, dynamic>{
-      'level1': instance.level1,
+      'level1': instance.level1?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -52,7 +52,7 @@ FragmentF1$level1 _$FragmentF1$level1FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF1$level1ToJson(FragmentF1$level1 instance) =>
     <String, dynamic>{
-      'level2': instance.level2,
+      'level2': instance.level2?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -69,7 +69,7 @@ FragmentF1$level1$level2 _$FragmentF1$level1$level2FromJson(
 Map<String, dynamic> _$FragmentF1$level1$level2ToJson(
         FragmentF1$level1$level2 instance) =>
     <String, dynamic>{
-      'level3': instance.level3,
+      'level3': instance.level3?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -109,7 +109,7 @@ FragmentF2 _$FragmentF2FromJson(Map<String, dynamic> json) => FragmentF2(
 
 Map<String, dynamic> _$FragmentF2ToJson(FragmentF2 instance) =>
     <String, dynamic>{
-      'level1': instance.level1,
+      'level1': instance.level1?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -124,7 +124,7 @@ FragmentF2$level1 _$FragmentF2$level1FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF2$level1ToJson(FragmentF2$level1 instance) =>
     <String, dynamic>{
-      'level2': instance.level2,
+      'level2': instance.level2?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -141,7 +141,7 @@ FragmentF2$level1$level2 _$FragmentF2$level1$level2FromJson(
 Map<String, dynamic> _$FragmentF2$level1$level2ToJson(
         FragmentF2$level1$level2 instance) =>
     <String, dynamic>{
-      'level3': instance.level3,
+      'level3': instance.level3?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -180,7 +180,7 @@ FragmentF21 _$FragmentF21FromJson(Map<String, dynamic> json) => FragmentF21(
 
 Map<String, dynamic> _$FragmentF21ToJson(FragmentF21 instance) =>
     <String, dynamic>{
-      'level2': instance.level2,
+      'level2': instance.level2?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -195,7 +195,7 @@ FragmentF21$level2 _$FragmentF21$level2FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF21$level2ToJson(FragmentF21$level2 instance) =>
     <String, dynamic>{
-      'level3': instance.level3,
+      'level3': instance.level3?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF extends JsonSerializable {
   FragmentF({required this.$__typename, this.name});
 
@@ -91,7 +91,7 @@ const FRAGMENT_F = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$T extends JsonSerializable implements FragmentF {
   FragmentF$T({required this.$__typename, this.name, this.t});
 
@@ -133,7 +133,7 @@ class FragmentF$T extends JsonSerializable implements FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$T$t extends JsonSerializable {
   FragmentF$T$t({this.name});
 
@@ -162,7 +162,7 @@ class FragmentF$T$t extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
 
@@ -214,7 +214,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t extends JsonSerializable implements FragmentF$T {
   QueryQ$t({required this.$__typename, this.name, this.t});
 
@@ -255,7 +255,7 @@ class QueryQ$t extends JsonSerializable implements FragmentF$T {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable implements FragmentF$T$t {
   QueryQ$t$t({this.name});
 

--- a/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
@@ -43,6 +43,13 @@ class FragmentF extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF on FragmentF {
+  FragmentF copyWith({String? $__typename, String? Function()? name}) =>
+      FragmentF(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F = const FragmentDefinitionNode(
     name: NameNode(value: 'F'),
     typeCondition: TypeConditionNode(
@@ -133,6 +140,17 @@ class FragmentF$T extends JsonSerializable implements FragmentF {
   }
 }
 
+extension UtilityExtensionFragmentF$T on FragmentF$T {
+  FragmentF$T copyWith(
+          {String? $__typename,
+          String? Function()? name,
+          FragmentF$T$t? Function()? t}) =>
+      FragmentF$T(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name(),
+          t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF$T$t extends JsonSerializable {
   FragmentF$T$t({this.name});
@@ -162,6 +180,11 @@ class FragmentF$T$t extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF$T$t on FragmentF$T$t {
+  FragmentF$T$t copyWith({String? Function()? name}) =>
+      FragmentF$T$t(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
@@ -187,6 +210,11 @@ class QueryQ extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$t? Function()? t}) =>
+      QueryQ(t: t == null ? this.t : t());
 }
 
 const QUERY_Q = const DocumentNode(definitions: [
@@ -255,6 +283,17 @@ class QueryQ$t extends JsonSerializable implements FragmentF$T {
   }
 }
 
+extension UtilityExtensionQueryQ$t on QueryQ$t {
+  QueryQ$t copyWith(
+          {String? $__typename,
+          String? Function()? name,
+          QueryQ$t$t? Function()? t}) =>
+      QueryQ$t(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name(),
+          t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable implements FragmentF$T$t {
   QueryQ$t$t({this.name});
@@ -282,6 +321,11 @@ class QueryQ$t$t extends JsonSerializable implements FragmentF$T$t {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$t$t on QueryQ$t$t {
+  QueryQ$t$t copyWith({String? Function()? name}) =>
+      QueryQ$t$t(name: name == null ? this.name : name());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.g.dart
@@ -28,7 +28,7 @@ Map<String, dynamic> _$FragmentF$TToJson(FragmentF$T instance) =>
     <String, dynamic>{
       '__typename': instance.$__typename,
       'name': instance.name,
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 FragmentF$T$t _$FragmentF$T$tFromJson(Map<String, dynamic> json) =>
@@ -48,7 +48,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
@@ -62,7 +62,7 @@ QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
 Map<String, dynamic> _$QueryQ$tToJson(QueryQ$t instance) => <String, dynamic>{
       '__typename': instance.$__typename,
       'name': instance.name,
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t$t _$QueryQ$t$tFromJson(Map<String, dynamic> json) => QueryQ$t$t(

--- a/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF extends JsonSerializable {
   FragmentF({this.other});
 
@@ -63,7 +63,7 @@ const FRAGMENT_F = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other extends JsonSerializable implements FragmentF2 {
   FragmentF$other({this.other});
 
@@ -92,7 +92,7 @@ class FragmentF$other extends JsonSerializable implements FragmentF2 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other$other extends JsonSerializable
     implements FragmentF2$other {
   FragmentF$other$other({this.name});
@@ -122,7 +122,7 @@ class FragmentF$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other$T1 extends JsonSerializable implements FragmentF$other {
   FragmentF$other$T1({this.other, this.b});
 
@@ -157,7 +157,7 @@ class FragmentF$other$T1 extends JsonSerializable implements FragmentF$other {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.other});
 
@@ -210,7 +210,7 @@ const FRAGMENT_F2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$other extends JsonSerializable {
   FragmentF2$other({this.name});
 
@@ -239,7 +239,7 @@ class FragmentF2$other extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch extends JsonSerializable {
   QueryFetch({this.t});
 
@@ -288,7 +288,7 @@ const QUERY_FETCH = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t extends JsonSerializable implements FragmentF {
   QueryFetch$t({this.other});
 
@@ -317,7 +317,7 @@ class QueryFetch$t extends JsonSerializable implements FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other extends JsonSerializable
     implements FragmentF$other, FragmentF2 {
   QueryFetch$t$other({this.other});
@@ -347,7 +347,7 @@ class QueryFetch$t$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$other extends JsonSerializable
     implements FragmentF$other$other, FragmentF2$other {
   QueryFetch$t$other$other({this.name});
@@ -377,7 +377,7 @@ class QueryFetch$t$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$T1 extends JsonSerializable
     implements FragmentF$other$T1, QueryFetch$t$other {
   QueryFetch$t$other$T1({this.other, this.b});

--- a/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
@@ -30,6 +30,11 @@ class FragmentF extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF on FragmentF {
+  FragmentF copyWith({FragmentF$other? Function()? other}) =>
+      FragmentF(other: other == null ? this.other : other());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F = const FragmentDefinitionNode(
     name: NameNode(value: 'F'),
     typeCondition: TypeConditionNode(
@@ -92,6 +97,11 @@ class FragmentF$other extends JsonSerializable implements FragmentF2 {
   }
 }
 
+extension UtilityExtensionFragmentF$other on FragmentF$other {
+  FragmentF$other copyWith({FragmentF$other$other? Function()? other}) =>
+      FragmentF$other(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF$other$other extends JsonSerializable
     implements FragmentF2$other {
@@ -120,6 +130,11 @@ class FragmentF$other$other extends JsonSerializable
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF$other$other on FragmentF$other$other {
+  FragmentF$other$other copyWith({String? Function()? name}) =>
+      FragmentF$other$other(name: name == null ? this.name : name());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -157,6 +172,14 @@ class FragmentF$other$T1 extends JsonSerializable implements FragmentF$other {
   }
 }
 
+extension UtilityExtensionFragmentF$other$T1 on FragmentF$other$T1 {
+  FragmentF$other$T1 copyWith(
+          {FragmentF$other$other? Function()? other, bool? Function()? b}) =>
+      FragmentF$other$T1(
+          other: other == null ? this.other : other(),
+          b: b == null ? this.b : b());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.other});
@@ -184,6 +207,11 @@ class FragmentF2 extends JsonSerializable {
     if (l$other != lOther$other) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith({FragmentF2$other? Function()? other}) =>
+      FragmentF2(other: other == null ? this.other : other());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
@@ -239,6 +267,11 @@ class FragmentF2$other extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF2$other on FragmentF2$other {
+  FragmentF2$other copyWith({String? Function()? name}) =>
+      FragmentF2$other(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetch extends JsonSerializable {
   QueryFetch({this.t});
@@ -266,6 +299,11 @@ class QueryFetch extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch on QueryFetch {
+  QueryFetch copyWith({QueryFetch$t? Function()? t}) =>
+      QueryFetch(t: t == null ? this.t : t());
 }
 
 const QUERY_FETCH = const DocumentNode(definitions: [
@@ -317,6 +355,11 @@ class QueryFetch$t extends JsonSerializable implements FragmentF {
   }
 }
 
+extension UtilityExtensionQueryFetch$t on QueryFetch$t {
+  QueryFetch$t copyWith({QueryFetch$t$other? Function()? other}) =>
+      QueryFetch$t(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other extends JsonSerializable
     implements FragmentF$other, FragmentF2 {
@@ -347,6 +390,11 @@ class QueryFetch$t$other extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetch$t$other on QueryFetch$t$other {
+  QueryFetch$t$other copyWith({QueryFetch$t$other$other? Function()? other}) =>
+      QueryFetch$t$other(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$other extends JsonSerializable
     implements FragmentF$other$other, FragmentF2$other {
@@ -375,6 +423,11 @@ class QueryFetch$t$other$other extends JsonSerializable
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch$t$other$other on QueryFetch$t$other$other {
+  QueryFetch$t$other$other copyWith({String? Function()? name}) =>
+      QueryFetch$t$other$other(name: name == null ? this.name : name());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -411,6 +464,14 @@ class QueryFetch$t$other$T1 extends JsonSerializable
     if (l$b != lOther$b) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch$t$other$T1 on QueryFetch$t$other$T1 {
+  QueryFetch$t$other$T1 copyWith(
+          {QueryFetch$t$other$other? Function()? other, bool? Function()? b}) =>
+      QueryFetch$t$other$T1(
+          other: other == null ? this.other : other(),
+          b: b == null ? this.b : b());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.g.dart
@@ -13,7 +13,7 @@ FragmentF _$FragmentFFromJson(Map<String, dynamic> json) => FragmentF(
     );
 
 Map<String, dynamic> _$FragmentFToJson(FragmentF instance) => <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF$other _$FragmentF$otherFromJson(Map<String, dynamic> json) =>
@@ -26,7 +26,7 @@ FragmentF$other _$FragmentF$otherFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF$otherToJson(FragmentF$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF$other$other _$FragmentF$other$otherFromJson(
@@ -52,7 +52,7 @@ FragmentF$other$T1 _$FragmentF$other$T1FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF$other$T1ToJson(FragmentF$other$T1 instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
       'b': instance.b,
     };
 
@@ -64,7 +64,7 @@ FragmentF2 _$FragmentF2FromJson(Map<String, dynamic> json) => FragmentF2(
 
 Map<String, dynamic> _$FragmentF2ToJson(FragmentF2 instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF2$other _$FragmentF2$otherFromJson(Map<String, dynamic> json) =>
@@ -85,7 +85,7 @@ QueryFetch _$QueryFetchFromJson(Map<String, dynamic> json) => QueryFetch(
 
 Map<String, dynamic> _$QueryFetchToJson(QueryFetch instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryFetch$t _$QueryFetch$tFromJson(Map<String, dynamic> json) => QueryFetch$t(
@@ -96,7 +96,7 @@ QueryFetch$t _$QueryFetch$tFromJson(Map<String, dynamic> json) => QueryFetch$t(
 
 Map<String, dynamic> _$QueryFetch$tToJson(QueryFetch$t instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 QueryFetch$t$other _$QueryFetch$t$otherFromJson(Map<String, dynamic> json) =>
@@ -109,7 +109,7 @@ QueryFetch$t$other _$QueryFetch$t$otherFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetch$t$otherToJson(QueryFetch$t$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 QueryFetch$t$other$other _$QueryFetch$t$other$otherFromJson(
@@ -137,6 +137,6 @@ QueryFetch$t$other$T1 _$QueryFetch$t$other$T1FromJson(
 Map<String, dynamic> _$QueryFetch$t$other$T1ToJson(
         QueryFetch$t$other$T1 instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
       'b': instance.b,
     };

--- a/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
@@ -30,6 +30,11 @@ class FragmentF extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF on FragmentF {
+  FragmentF copyWith({FragmentF$other? Function()? other}) =>
+      FragmentF(other: other == null ? this.other : other());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F = const FragmentDefinitionNode(
     name: NameNode(value: 'F'),
     typeCondition: TypeConditionNode(
@@ -81,6 +86,11 @@ class FragmentF$other extends JsonSerializable implements FragmentF2 {
   }
 }
 
+extension UtilityExtensionFragmentF$other on FragmentF$other {
+  FragmentF$other copyWith({FragmentF$other$other? Function()? other}) =>
+      FragmentF$other(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF$other$other extends JsonSerializable
     implements FragmentF2$other, FragmentF3 {
@@ -109,6 +119,12 @@ class FragmentF$other$other extends JsonSerializable
     if (l$other != lOther$other) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF$other$other on FragmentF$other$other {
+  FragmentF$other$other copyWith(
+          {FragmentF$other$other$other? Function()? other}) =>
+      FragmentF$other$other(other: other == null ? this.other : other());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -141,6 +157,12 @@ class FragmentF$other$other$other extends JsonSerializable
   }
 }
 
+extension UtilityExtensionFragmentF$other$other$other
+    on FragmentF$other$other$other {
+  FragmentF$other$other$other copyWith({String? Function()? name}) =>
+      FragmentF$other$other$other(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.other});
@@ -168,6 +190,11 @@ class FragmentF2 extends JsonSerializable {
     if (l$other != lOther$other) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith({FragmentF2$other? Function()? other}) =>
+      FragmentF2(other: other == null ? this.other : other());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
@@ -220,6 +247,11 @@ class FragmentF2$other extends JsonSerializable implements FragmentF3 {
   }
 }
 
+extension UtilityExtensionFragmentF2$other on FragmentF2$other {
+  FragmentF2$other copyWith({FragmentF2$other$other? Function()? other}) =>
+      FragmentF2$other(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF2$other$other extends JsonSerializable
     implements FragmentF3$other, FragmentF4 {
@@ -250,6 +282,11 @@ class FragmentF2$other$other extends JsonSerializable
   }
 }
 
+extension UtilityExtensionFragmentF2$other$other on FragmentF2$other$other {
+  FragmentF2$other$other copyWith({String? Function()? name}) =>
+      FragmentF2$other$other(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF3 extends JsonSerializable {
   FragmentF3({this.other});
@@ -277,6 +314,11 @@ class FragmentF3 extends JsonSerializable {
     if (l$other != lOther$other) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF3 on FragmentF3 {
+  FragmentF3 copyWith({FragmentF3$other? Function()? other}) =>
+      FragmentF3(other: other == null ? this.other : other());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F3 = const FragmentDefinitionNode(
@@ -328,6 +370,11 @@ class FragmentF3$other extends JsonSerializable implements FragmentF4 {
   }
 }
 
+extension UtilityExtensionFragmentF3$other on FragmentF3$other {
+  FragmentF3$other copyWith({String? Function()? name}) =>
+      FragmentF3$other(name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF4 extends JsonSerializable {
   FragmentF4({this.name});
@@ -355,6 +402,11 @@ class FragmentF4 extends JsonSerializable {
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF4 on FragmentF4 {
+  FragmentF4 copyWith({String? Function()? name}) =>
+      FragmentF4(name: name == null ? this.name : name());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F4 = const FragmentDefinitionNode(
@@ -401,6 +453,11 @@ class QueryFetch extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch on QueryFetch {
+  QueryFetch copyWith({QueryFetch$t? Function()? t}) =>
+      QueryFetch(t: t == null ? this.t : t());
 }
 
 const QUERY_FETCH = const DocumentNode(definitions: [
@@ -454,6 +511,11 @@ class QueryFetch$t extends JsonSerializable implements FragmentF {
   }
 }
 
+extension UtilityExtensionQueryFetch$t on QueryFetch$t {
+  QueryFetch$t copyWith({QueryFetch$t$other? Function()? other}) =>
+      QueryFetch$t(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other extends JsonSerializable
     implements FragmentF$other, FragmentF2 {
@@ -484,6 +546,11 @@ class QueryFetch$t$other extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetch$t$other on QueryFetch$t$other {
+  QueryFetch$t$other copyWith({QueryFetch$t$other$other? Function()? other}) =>
+      QueryFetch$t$other(other: other == null ? this.other : other());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$other extends JsonSerializable
     implements FragmentF$other$other, FragmentF2$other, FragmentF3 {
@@ -512,6 +579,12 @@ class QueryFetch$t$other$other extends JsonSerializable
     if (l$other != lOther$other) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch$t$other$other on QueryFetch$t$other$other {
+  QueryFetch$t$other$other copyWith(
+          {QueryFetch$t$other$other$other? Function()? other}) =>
+      QueryFetch$t$other$other(other: other == null ? this.other : other());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -546,6 +619,12 @@ class QueryFetch$t$other$other$other extends JsonSerializable
     if (l$name != lOther$name) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetch$t$other$other$other
+    on QueryFetch$t$other$other$other {
+  QueryFetch$t$other$other$other copyWith({String? Function()? name}) =>
+      QueryFetch$t$other$other$other(name: name == null ? this.name : name());
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF extends JsonSerializable {
   FragmentF({this.other});
 
@@ -52,7 +52,7 @@ const FRAGMENT_F = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F4,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other extends JsonSerializable implements FragmentF2 {
   FragmentF$other({this.other});
 
@@ -81,7 +81,7 @@ class FragmentF$other extends JsonSerializable implements FragmentF2 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other$other extends JsonSerializable
     implements FragmentF2$other, FragmentF3 {
   FragmentF$other$other({this.other});
@@ -111,7 +111,7 @@ class FragmentF$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$other$other$other extends JsonSerializable
     implements FragmentF2$other$other, FragmentF3$other, FragmentF4 {
   FragmentF$other$other$other({this.name});
@@ -141,7 +141,7 @@ class FragmentF$other$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.other});
 
@@ -191,7 +191,7 @@ const FRAGMENT_F2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F4,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$other extends JsonSerializable implements FragmentF3 {
   FragmentF2$other({this.other});
 
@@ -220,7 +220,7 @@ class FragmentF2$other extends JsonSerializable implements FragmentF3 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2$other$other extends JsonSerializable
     implements FragmentF3$other, FragmentF4 {
   FragmentF2$other$other({this.name});
@@ -250,7 +250,7 @@ class FragmentF2$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF3 extends JsonSerializable {
   FragmentF3({this.other});
 
@@ -299,7 +299,7 @@ const FRAGMENT_F3 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F4,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF3$other extends JsonSerializable implements FragmentF4 {
   FragmentF3$other({this.name});
 
@@ -328,7 +328,7 @@ class FragmentF3$other extends JsonSerializable implements FragmentF4 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF4 extends JsonSerializable {
   FragmentF4({this.name});
 
@@ -374,7 +374,7 @@ const FRAGMENT_F4 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F4,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch extends JsonSerializable {
   QueryFetch({this.t});
 
@@ -425,7 +425,7 @@ const QUERY_FETCH = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F4,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t extends JsonSerializable implements FragmentF {
   QueryFetch$t({this.other});
 
@@ -454,7 +454,7 @@ class QueryFetch$t extends JsonSerializable implements FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other extends JsonSerializable
     implements FragmentF$other, FragmentF2 {
   QueryFetch$t$other({this.other});
@@ -484,7 +484,7 @@ class QueryFetch$t$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$other extends JsonSerializable
     implements FragmentF$other$other, FragmentF2$other, FragmentF3 {
   QueryFetch$t$other$other({this.other});
@@ -514,7 +514,7 @@ class QueryFetch$t$other$other extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetch$t$other$other$other extends JsonSerializable
     implements
         FragmentF$other$other$other,

--- a/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.g.dart
@@ -13,7 +13,7 @@ FragmentF _$FragmentFFromJson(Map<String, dynamic> json) => FragmentF(
     );
 
 Map<String, dynamic> _$FragmentFToJson(FragmentF instance) => <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF$other _$FragmentF$otherFromJson(Map<String, dynamic> json) =>
@@ -26,7 +26,7 @@ FragmentF$other _$FragmentF$otherFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF$otherToJson(FragmentF$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF$other$other _$FragmentF$other$otherFromJson(
@@ -41,7 +41,7 @@ FragmentF$other$other _$FragmentF$other$otherFromJson(
 Map<String, dynamic> _$FragmentF$other$otherToJson(
         FragmentF$other$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF$other$other$other _$FragmentF$other$other$otherFromJson(
@@ -64,7 +64,7 @@ FragmentF2 _$FragmentF2FromJson(Map<String, dynamic> json) => FragmentF2(
 
 Map<String, dynamic> _$FragmentF2ToJson(FragmentF2 instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF2$other _$FragmentF2$otherFromJson(Map<String, dynamic> json) =>
@@ -77,7 +77,7 @@ FragmentF2$other _$FragmentF2$otherFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$FragmentF2$otherToJson(FragmentF2$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF2$other$other _$FragmentF2$other$otherFromJson(
@@ -100,7 +100,7 @@ FragmentF3 _$FragmentF3FromJson(Map<String, dynamic> json) => FragmentF3(
 
 Map<String, dynamic> _$FragmentF3ToJson(FragmentF3 instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 FragmentF3$other _$FragmentF3$otherFromJson(Map<String, dynamic> json) =>
@@ -130,7 +130,7 @@ QueryFetch _$QueryFetchFromJson(Map<String, dynamic> json) => QueryFetch(
 
 Map<String, dynamic> _$QueryFetchToJson(QueryFetch instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryFetch$t _$QueryFetch$tFromJson(Map<String, dynamic> json) => QueryFetch$t(
@@ -141,7 +141,7 @@ QueryFetch$t _$QueryFetch$tFromJson(Map<String, dynamic> json) => QueryFetch$t(
 
 Map<String, dynamic> _$QueryFetch$tToJson(QueryFetch$t instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 QueryFetch$t$other _$QueryFetch$t$otherFromJson(Map<String, dynamic> json) =>
@@ -154,7 +154,7 @@ QueryFetch$t$other _$QueryFetch$t$otherFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetch$t$otherToJson(QueryFetch$t$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 QueryFetch$t$other$other _$QueryFetch$t$other$otherFromJson(
@@ -169,7 +169,7 @@ QueryFetch$t$other$other _$QueryFetch$t$other$otherFromJson(
 Map<String, dynamic> _$QueryFetch$t$other$otherToJson(
         QueryFetch$t$other$other instance) =>
     <String, dynamic>{
-      'other': instance.other,
+      'other': instance.other?.toJson(),
     };
 
 QueryFetch$t$other$other$other _$QueryFetch$t$other$other$otherFromJson(

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -4,7 +4,7 @@ import 'package:graphql/client.dart' as graphql;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentNoVariables extends JsonSerializable {
   FragmentNoVariables({this.s});
 
@@ -79,7 +79,7 @@ extension ClientExtensionFragmentNoVariables on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesFragmentWithOptionalVariables extends JsonSerializable {
   VariablesFragmentWithOptionalVariables({this.name});
 
@@ -110,7 +110,7 @@ class VariablesFragmentWithOptionalVariables extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentWithOptionalVariables extends JsonSerializable {
   FragmentWithOptionalVariables({this.s});
 
@@ -196,7 +196,7 @@ extension ClientExtensionFragmentWithOptionalVariables
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesFragmentWithVariables extends JsonSerializable {
   VariablesFragmentWithVariables({required this.name});
 
@@ -225,7 +225,7 @@ class VariablesFragmentWithVariables extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentWithVariables extends JsonSerializable {
   FragmentWithVariables({this.s2});
 
@@ -308,7 +308,7 @@ extension ClientExtensionFragmentWithVariables on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryFetchSOptional extends JsonSerializable {
   VariablesQueryFetchSOptional({this.name});
 
@@ -337,7 +337,7 @@ class VariablesQueryFetchSOptional extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSOptional extends JsonSerializable {
   QueryFetchSOptional({this.s});
 
@@ -487,7 +487,7 @@ extension ClientExtensionQueryFetchSOptional on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryFetchSRequired extends JsonSerializable {
   VariablesQueryFetchSRequired({required this.name});
 
@@ -516,7 +516,7 @@ class VariablesQueryFetchSRequired extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSRequired extends JsonSerializable {
   QueryFetchSRequired({this.s});
 
@@ -666,7 +666,7 @@ extension ClientExtensionQueryFetchSRequired on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSNoVariables extends JsonSerializable {
   QueryFetchSNoVariables({this.s});
 
@@ -798,7 +798,7 @@ extension ClientExtensionQueryFetchSNoVariables on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesMutationUpdateSOptional extends JsonSerializable {
   VariablesMutationUpdateSOptional({this.name});
 
@@ -829,7 +829,7 @@ class VariablesMutationUpdateSOptional extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSOptional extends JsonSerializable {
   MutationUpdateSOptional({this.s});
 
@@ -974,7 +974,7 @@ extension ClientExtensionMutationUpdateSOptional on graphql.GraphQLClient {
       this.watchMutation(options ?? WatchOptionsMutationUpdateSOptional());
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesMutationUpdateSRequired extends JsonSerializable {
   VariablesMutationUpdateSRequired({required this.name});
 
@@ -1005,7 +1005,7 @@ class VariablesMutationUpdateSRequired extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSRequired extends JsonSerializable {
   MutationUpdateSRequired({this.s});
 
@@ -1150,7 +1150,7 @@ extension ClientExtensionMutationUpdateSRequired on graphql.GraphQLClient {
       this.watchMutation(options);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSNoVariables extends JsonSerializable {
   MutationUpdateSNoVariables({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -33,6 +33,11 @@ class FragmentNoVariables extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentNoVariables on FragmentNoVariables {
+  FragmentNoVariables copyWith({String? Function()? s}) =>
+      FragmentNoVariables(s: s == null ? this.s : s());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_NO_VARIABLES = const FragmentDefinitionNode(
     name: NameNode(value: 'NoVariables'),
     typeCondition: TypeConditionNode(
@@ -137,6 +142,12 @@ class FragmentWithOptionalVariables extends JsonSerializable {
     if (l$s != lOther$s) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentWithOptionalVariables
+    on FragmentWithOptionalVariables {
+  FragmentWithOptionalVariables copyWith({String? Function()? s}) =>
+      FragmentWithOptionalVariables(s: s == null ? this.s : s());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_WITH_OPTIONAL_VARIABLES =
@@ -254,6 +265,11 @@ class FragmentWithVariables extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentWithVariables on FragmentWithVariables {
+  FragmentWithVariables copyWith({String? Function()? s2}) =>
+      FragmentWithVariables(s2: s2 == null ? this.s2 : s2());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_WITH_VARIABLES =
     const FragmentDefinitionNode(
         name: NameNode(value: 'WithVariables'),
@@ -364,6 +380,11 @@ class QueryFetchSOptional extends JsonSerializable {
     if (l$s != lOther$s) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchSOptional on QueryFetchSOptional {
+  QueryFetchSOptional copyWith({String? Function()? s}) =>
+      QueryFetchSOptional(s: s == null ? this.s : s());
 }
 
 const QUERY_FETCH_S_OPTIONAL = const DocumentNode(definitions: [
@@ -545,6 +566,11 @@ class QueryFetchSRequired extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchSRequired on QueryFetchSRequired {
+  QueryFetchSRequired copyWith({String? Function()? s}) =>
+      QueryFetchSRequired(s: s == null ? this.s : s());
+}
+
 const QUERY_FETCH_S_REQUIRED = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -693,6 +719,11 @@ class QueryFetchSNoVariables extends JsonSerializable {
     if (l$s != lOther$s) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchSNoVariables on QueryFetchSNoVariables {
+  QueryFetchSNoVariables copyWith({String? Function()? s}) =>
+      QueryFetchSNoVariables(s: s == null ? this.s : s());
 }
 
 const QUERY_FETCH_S_NO_VARIABLES = const DocumentNode(definitions: [
@@ -856,6 +887,11 @@ class MutationUpdateSOptional extends JsonSerializable {
     if (l$s != lOther$s) return false;
     return true;
   }
+}
+
+extension UtilityExtensionMutationUpdateSOptional on MutationUpdateSOptional {
+  MutationUpdateSOptional copyWith({String? Function()? s}) =>
+      MutationUpdateSOptional(s: s == null ? this.s : s());
 }
 
 const MUTATION_UPDATE_S_OPTIONAL = const DocumentNode(definitions: [
@@ -1034,6 +1070,11 @@ class MutationUpdateSRequired extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionMutationUpdateSRequired on MutationUpdateSRequired {
+  MutationUpdateSRequired copyWith({String? Function()? s}) =>
+      MutationUpdateSRequired(s: s == null ? this.s : s());
+}
+
 const MUTATION_UPDATE_S_REQUIRED = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.mutation,
@@ -1177,6 +1218,12 @@ class MutationUpdateSNoVariables extends JsonSerializable {
     if (l$s != lOther$s) return false;
     return true;
   }
+}
+
+extension UtilityExtensionMutationUpdateSNoVariables
+    on MutationUpdateSNoVariables {
+  MutationUpdateSNoVariables copyWith({String? Function()? s}) =>
+      MutationUpdateSNoVariables(s: s == null ? this.s : s());
 }
 
 const MUTATION_UPDATE_S_NO_VARIABLES = const DocumentNode(definitions: [

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
@@ -46,6 +46,17 @@ class FragmentF1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF1 on FragmentF1 {
+  FragmentF1 copyWith(
+          {String? Function()? name,
+          FragmentF1$field? Function()? field,
+          String? $__typename}) =>
+      FragmentF1(
+          name: name == null ? this.name : name(),
+          field: field == null ? this.field : field(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F1 = const FragmentDefinitionNode(
     name: NameNode(value: 'F1'),
     typeCondition: TypeConditionNode(
@@ -142,6 +153,13 @@ class FragmentF1$field extends JsonSerializable implements FragmentF2 {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF1$field on FragmentF1$field {
+  FragmentF1$field copyWith({String? Function()? name, String? $__typename}) =>
+      FragmentF1$field(
+          name: name == null ? this.name : name(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
@@ -4,7 +4,7 @@ import 'package:graphql/client.dart' as graphql;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1 extends JsonSerializable {
   FragmentF1({this.name, this.field, required this.$__typename});
 
@@ -108,7 +108,7 @@ extension ClientExtensionFragmentF1 on graphql.GraphQLClient {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1$field extends JsonSerializable implements FragmentF2 {
   FragmentF1$field({this.name, required this.$__typename});
 

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.g.dart
@@ -17,7 +17,7 @@ FragmentF1 _$FragmentF1FromJson(Map<String, dynamic> json) => FragmentF1(
 Map<String, dynamic> _$FragmentF1ToJson(FragmentF1 instance) =>
     <String, dynamic>{
       'name': instance.name,
-      'field': instance.field,
+      'field': instance.field?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
@@ -39,6 +39,13 @@ class FragmentF2 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith({String? Function()? name, String? $__typename}) =>
+      FragmentF2(
+          name: name == null ? this.name : name(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
     name: NameNode(value: 'F2'),
     typeCondition: TypeConditionNode(

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
@@ -3,7 +3,7 @@ import 'package:graphql/client.dart' as graphql;
 import 'package:json_annotation/json_annotation.dart';
 part 'document2.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.name, required this.$__typename});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
@@ -6,7 +6,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSNo extends JsonSerializable {
   MutationUpdateSNo({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
@@ -35,6 +35,11 @@ class MutationUpdateSNo extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionMutationUpdateSNo on MutationUpdateSNo {
+  MutationUpdateSNo copyWith({String? Function()? s}) =>
+      MutationUpdateSNo(s: s == null ? this.s : s());
+}
+
 const MUTATION_UPDATE_S_NO = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.mutation,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
@@ -6,7 +6,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesMutationUpdateSOptional extends JsonSerializable {
   VariablesMutationUpdateSOptional({this.name});
 
@@ -37,7 +37,7 @@ class VariablesMutationUpdateSOptional extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSOptional extends JsonSerializable {
   MutationUpdateSOptional({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
@@ -66,6 +66,11 @@ class MutationUpdateSOptional extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionMutationUpdateSOptional on MutationUpdateSOptional {
+  MutationUpdateSOptional copyWith({String? Function()? s}) =>
+      MutationUpdateSOptional(s: s == null ? this.s : s());
+}
+
 const MUTATION_UPDATE_S_OPTIONAL = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.mutation,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -66,6 +66,11 @@ class MutationUpdateSRequired extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionMutationUpdateSRequired on MutationUpdateSRequired {
+  MutationUpdateSRequired copyWith({String? Function()? s}) =>
+      MutationUpdateSRequired(s: s == null ? this.s : s());
+}
+
 const MUTATION_UPDATE_S_REQUIRED = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.mutation,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -6,7 +6,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesMutationUpdateSRequired extends JsonSerializable {
   VariablesMutationUpdateSRequired({required this.name});
 
@@ -37,7 +37,7 @@ class VariablesMutationUpdateSRequired extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class MutationUpdateSRequired extends JsonSerializable {
   MutationUpdateSRequired({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -5,7 +5,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSNoVariables extends JsonSerializable {
   QueryFetchSNoVariables({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -34,6 +34,11 @@ class QueryFetchSNoVariables extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchSNoVariables on QueryFetchSNoVariables {
+  QueryFetchSNoVariables copyWith({String? Function()? s}) =>
+      QueryFetchSNoVariables(s: s == null ? this.s : s());
+}
+
 const QUERY_FETCH_S_NO_VARIABLES = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -5,7 +5,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryFetchSOptional extends JsonSerializable {
   VariablesQueryFetchSOptional({this.name});
 
@@ -34,7 +34,7 @@ class VariablesQueryFetchSOptional extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSOptional extends JsonSerializable {
   QueryFetchSOptional({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -63,6 +63,11 @@ class QueryFetchSOptional extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchSOptional on QueryFetchSOptional {
+  QueryFetchSOptional copyWith({String? Function()? s}) =>
+      QueryFetchSOptional(s: s == null ? this.s : s());
+}
+
 const QUERY_FETCH_S_OPTIONAL = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -63,6 +63,11 @@ class QueryFetchSRequired extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchSRequired on QueryFetchSRequired {
+  QueryFetchSRequired copyWith({String? Function()? s}) =>
+      QueryFetchSRequired(s: s == null ? this.s : s());
+}
+
 const QUERY_FETCH_S_REQUIRED = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -5,7 +5,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryFetchSRequired extends JsonSerializable {
   VariablesQueryFetchSRequired({required this.name});
 
@@ -34,7 +34,7 @@ class VariablesQueryFetchSRequired extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchSRequired extends JsonSerializable {
   QueryFetchSRequired({this.s});
 

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -42,6 +42,17 @@ class SubscriptionNoArgs extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionSubscriptionNoArgs on SubscriptionNoArgs {
+  SubscriptionNoArgs copyWith(
+          {SubscriptionNoArgs$listenForChange? Function()? listenForChange,
+          String? $__typename}) =>
+      SubscriptionNoArgs(
+          listenForChange: listenForChange == null
+              ? this.listenForChange
+              : listenForChange(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const SUBSCRIPTION_NO_ARGS = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.subscription,
@@ -199,6 +210,15 @@ class SubscriptionNoArgs$listenForChange extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionSubscriptionNoArgs$listenForChange
+    on SubscriptionNoArgs$listenForChange {
+  SubscriptionNoArgs$listenForChange copyWith(
+          {String? name, String? $__typename}) =>
+      SubscriptionNoArgs$listenForChange(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionRequiredArg extends JsonSerializable {
   VariablesSubscriptionRequiredArg({required this.name});
@@ -264,6 +284,17 @@ class SubscriptionRequiredArg extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionSubscriptionRequiredArg on SubscriptionRequiredArg {
+  SubscriptionRequiredArg copyWith(
+          {SubscriptionRequiredArg$listenForChange? Function()? listenForChange,
+          String? $__typename}) =>
+      SubscriptionRequiredArg(
+          listenForChange: listenForChange == null
+              ? this.listenForChange
+              : listenForChange(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const SUBSCRIPTION_REQUIRED_ARG = const DocumentNode(definitions: [
@@ -445,6 +476,15 @@ class SubscriptionRequiredArg$listenForChange extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionSubscriptionRequiredArg$listenForChange
+    on SubscriptionRequiredArg$listenForChange {
+  SubscriptionRequiredArg$listenForChange copyWith(
+          {String? name, String? $__typename}) =>
+      SubscriptionRequiredArg$listenForChange(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionOptionalArg extends JsonSerializable {
   VariablesSubscriptionOptionalArg({this.name});
@@ -510,6 +550,17 @@ class SubscriptionOptionalArg extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionSubscriptionOptionalArg on SubscriptionOptionalArg {
+  SubscriptionOptionalArg copyWith(
+          {SubscriptionOptionalArg$listenForChange? Function()? listenForChange,
+          String? $__typename}) =>
+      SubscriptionOptionalArg(
+          listenForChange: listenForChange == null
+              ? this.listenForChange
+              : listenForChange(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const SUBSCRIPTION_OPTIONAL_ARG = const DocumentNode(definitions: [
@@ -689,6 +740,15 @@ class SubscriptionOptionalArg$listenForChange extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionSubscriptionOptionalArg$listenForChange
+    on SubscriptionOptionalArg$listenForChange {
+  SubscriptionOptionalArg$listenForChange copyWith(
+          {String? name, String? $__typename}) =>
+      SubscriptionOptionalArg$listenForChange(
+          name: name == null ? this.name : name,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -6,7 +6,7 @@ import 'package:graphql_flutter/graphql_flutter.dart' as graphql_flutter;
 import 'package:json_annotation/json_annotation.dart';
 part 'schema.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionNoArgs extends JsonSerializable {
   SubscriptionNoArgs({this.listenForChange, required this.$__typename});
 
@@ -160,7 +160,7 @@ class SubscriptionNoArgsWidget
             onSubscriptionResult: onSubscriptionResult);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionNoArgs$listenForChange extends JsonSerializable {
   SubscriptionNoArgs$listenForChange(
       {required this.name, required this.$__typename});
@@ -199,7 +199,7 @@ class SubscriptionNoArgs$listenForChange extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionRequiredArg extends JsonSerializable {
   VariablesSubscriptionRequiredArg({required this.name});
 
@@ -230,7 +230,7 @@ class VariablesSubscriptionRequiredArg extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionRequiredArg extends JsonSerializable {
   SubscriptionRequiredArg({this.listenForChange, required this.$__typename});
 
@@ -406,7 +406,7 @@ class SubscriptionRequiredArgWidget
             onSubscriptionResult: onSubscriptionResult);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionRequiredArg$listenForChange extends JsonSerializable {
   SubscriptionRequiredArg$listenForChange(
       {required this.name, required this.$__typename});
@@ -445,7 +445,7 @@ class SubscriptionRequiredArg$listenForChange extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesSubscriptionOptionalArg extends JsonSerializable {
   VariablesSubscriptionOptionalArg({this.name});
 
@@ -476,7 +476,7 @@ class VariablesSubscriptionOptionalArg extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionOptionalArg extends JsonSerializable {
   SubscriptionOptionalArg({this.listenForChange, required this.$__typename});
 
@@ -652,7 +652,7 @@ class SubscriptionOptionalArgWidget
             onSubscriptionResult: onSubscriptionResult);
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class SubscriptionOptionalArg$listenForChange extends JsonSerializable {
   SubscriptionOptionalArg$listenForChange(
       {required this.name, required this.$__typename});

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.g.dart
@@ -17,7 +17,7 @@ SubscriptionNoArgs _$SubscriptionNoArgsFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$SubscriptionNoArgsToJson(SubscriptionNoArgs instance) =>
     <String, dynamic>{
-      'listenForChange': instance.listenForChange,
+      'listenForChange': instance.listenForChange?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -60,7 +60,7 @@ SubscriptionRequiredArg _$SubscriptionRequiredArgFromJson(
 Map<String, dynamic> _$SubscriptionRequiredArgToJson(
         SubscriptionRequiredArg instance) =>
     <String, dynamic>{
-      'listenForChange': instance.listenForChange,
+      'listenForChange': instance.listenForChange?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -104,7 +104,7 @@ SubscriptionOptionalArg _$SubscriptionOptionalArgFromJson(
 Map<String, dynamic> _$SubscriptionOptionalArgToJson(
         SubscriptionOptionalArg instance) =>
     <String, dynamic>{
-      'listenForChange': instance.listenForChange,
+      'listenForChange': instance.listenForChange?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/input/input.graphql.dart
+++ b/packages/graphql_codegen/test/assets/input/input.graphql.dart
@@ -1,7 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 part 'input.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class InputI1 extends JsonSerializable {
   InputI1({required this.s, this.nested_input, this.$_min});
 

--- a/packages/graphql_codegen/test/assets/input/input.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/input/input.graphql.g.dart
@@ -16,6 +16,6 @@ InputI1 _$InputI1FromJson(Map<String, dynamic> json) => InputI1(
 
 Map<String, dynamic> _$InputI1ToJson(InputI1 instance) => <String, dynamic>{
       's': instance.s,
-      'nested_input': instance.nested_input,
+      'nested_input': instance.nested_input?.toJson(),
       '_min': instance.$_min,
     };

--- a/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
@@ -38,6 +38,13 @@ class FragmentFragmentA extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentFragmentA on FragmentFragmentA {
+  FragmentFragmentA copyWith(
+          {String? Function()? s, String? Function()? $_s}) =>
+      FragmentFragmentA(
+          s: s == null ? this.s : s(), $_s: $_s == null ? this.$_s : $_s());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_A = const FragmentDefinitionNode(
     name: NameNode(value: 'FragmentA'),
     typeCondition: TypeConditionNode(
@@ -91,6 +98,11 @@ class FragmentFragmentB extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentFragmentB on FragmentFragmentB {
+  FragmentFragmentB copyWith({int? Function()? i}) =>
+      FragmentFragmentB(i: i == null ? this.i : i());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_B = const FragmentDefinitionNode(
     name: NameNode(value: 'FragmentB'),
     typeCondition: TypeConditionNode(
@@ -137,6 +149,14 @@ class QueryFetchImplementations extends JsonSerializable {
     if (l$$interface != lOther$$interface) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchImplementations
+    on QueryFetchImplementations {
+  QueryFetchImplementations copyWith(
+          {QueryFetchImplementations$interface? Function()? $interface}) =>
+      QueryFetchImplementations(
+          $interface: $interface == null ? this.$interface : $interface());
 }
 
 const QUERY_FETCH_IMPLEMENTATIONS = const DocumentNode(definitions: [
@@ -267,6 +287,18 @@ class QueryFetchImplementations$interface extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchImplementations$interface
+    on QueryFetchImplementations$interface {
+  QueryFetchImplementations$interface copyWith(
+          {String? typename,
+          bool? Function()? b,
+          QueryFetchImplementations$interface$self? self}) =>
+      QueryFetchImplementations$interface(
+          typename: typename == null ? this.typename : typename,
+          b: b == null ? this.b : b(),
+          self: self == null ? this.self : self);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$self extends JsonSerializable {
   QueryFetchImplementations$interface$self({required this.$__typename});
@@ -307,6 +339,13 @@ class QueryFetchImplementations$interface$self extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchImplementations$interface$self
+    on QueryFetchImplementations$interface$self {
+  QueryFetchImplementations$interface$self copyWith({String? $__typename}) =>
+      QueryFetchImplementations$interface$self(
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -357,6 +396,18 @@ class QueryFetchImplementations$interface$self$ImplementationA
   }
 }
 
+extension UtilityExtensionQueryFetchImplementations$interface$self$ImplementationA
+    on QueryFetchImplementations$interface$self$ImplementationA {
+  QueryFetchImplementations$interface$self$ImplementationA copyWith(
+          {String? $__typename,
+          String? Function()? s,
+          String? Function()? $_s}) =>
+      QueryFetchImplementations$interface$self$ImplementationA(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          s: s == null ? this.s : s(),
+          $_s: $_s == null ? this.$_s : $_s());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$self$ImplementationB
     extends JsonSerializable
@@ -396,6 +447,15 @@ class QueryFetchImplementations$interface$self$ImplementationB
     if (l$i != lOther$i) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchImplementations$interface$self$ImplementationB
+    on QueryFetchImplementations$interface$self$ImplementationB {
+  QueryFetchImplementations$interface$self$ImplementationB copyWith(
+          {String? $__typename, int? Function()? i}) =>
+      QueryFetchImplementations$interface$self$ImplementationB(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          i: i == null ? this.i : i());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -457,6 +517,22 @@ class QueryFetchImplementations$interface$ImplementationA
   }
 }
 
+extension UtilityExtensionQueryFetchImplementations$interface$ImplementationA
+    on QueryFetchImplementations$interface$ImplementationA {
+  QueryFetchImplementations$interface$ImplementationA copyWith(
+          {String? typename,
+          bool? Function()? b,
+          QueryFetchImplementations$interface$self? self,
+          String? Function()? s,
+          String? Function()? $_s}) =>
+      QueryFetchImplementations$interface$ImplementationA(
+          typename: typename == null ? this.typename : typename,
+          b: b == null ? this.b : b(),
+          self: self == null ? this.self : self,
+          s: s == null ? this.s : s(),
+          $_s: $_s == null ? this.$_s : $_s());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$ImplementationB
     extends JsonSerializable
@@ -507,4 +583,18 @@ class QueryFetchImplementations$interface$ImplementationB
     if (l$i != lOther$i) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchImplementations$interface$ImplementationB
+    on QueryFetchImplementations$interface$ImplementationB {
+  QueryFetchImplementations$interface$ImplementationB copyWith(
+          {String? typename,
+          bool? Function()? b,
+          QueryFetchImplementations$interface$self? self,
+          int? Function()? i}) =>
+      QueryFetchImplementations$interface$ImplementationB(
+          typename: typename == null ? this.typename : typename,
+          b: b == null ? this.b : b(),
+          self: self == null ? this.self : self,
+          i: i == null ? this.i : i());
 }

--- a/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'query.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentFragmentA extends JsonSerializable {
   FragmentFragmentA({this.s, this.$_s});
 
@@ -62,7 +62,7 @@ const FRAGMENT_FRAGMENT_A = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_A,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentFragmentB extends JsonSerializable {
   FragmentFragmentB({this.i});
 
@@ -109,7 +109,7 @@ const FRAGMENT_FRAGMENT_B = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_B,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations extends JsonSerializable {
   QueryFetchImplementations({this.$interface});
 
@@ -213,7 +213,7 @@ const QUERY_FETCH_IMPLEMENTATIONS = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_B,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface extends JsonSerializable {
   QueryFetchImplementations$interface(
       {required this.typename, this.b, required this.self});
@@ -267,7 +267,7 @@ class QueryFetchImplementations$interface extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$self extends JsonSerializable {
   QueryFetchImplementations$interface$self({required this.$__typename});
 
@@ -309,7 +309,7 @@ class QueryFetchImplementations$interface$self extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$self$ImplementationA
     extends JsonSerializable
     implements FragmentFragmentA, QueryFetchImplementations$interface$self {
@@ -357,7 +357,7 @@ class QueryFetchImplementations$interface$self$ImplementationA
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$self$ImplementationB
     extends JsonSerializable
     implements FragmentFragmentB, QueryFetchImplementations$interface$self {
@@ -398,7 +398,7 @@ class QueryFetchImplementations$interface$self$ImplementationB
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$ImplementationA
     extends JsonSerializable
     implements FragmentFragmentA, QueryFetchImplementations$interface {
@@ -457,7 +457,7 @@ class QueryFetchImplementations$interface$ImplementationA
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchImplementations$interface$ImplementationB
     extends JsonSerializable
     implements FragmentFragmentB, QueryFetchImplementations$interface {

--- a/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.g.dart
@@ -40,7 +40,7 @@ QueryFetchImplementations _$QueryFetchImplementationsFromJson(
 Map<String, dynamic> _$QueryFetchImplementationsToJson(
         QueryFetchImplementations instance) =>
     <String, dynamic>{
-      'interface': instance.$interface,
+      'interface': instance.$interface?.toJson(),
     };
 
 QueryFetchImplementations$interface
@@ -57,7 +57,7 @@ Map<String, dynamic> _$QueryFetchImplementations$interfaceToJson(
     <String, dynamic>{
       'typename': instance.typename,
       'b': instance.b,
-      'self': instance.self,
+      'self': instance.self.toJson(),
     };
 
 QueryFetchImplementations$interface$self
@@ -125,7 +125,7 @@ Map<String, dynamic>
         <String, dynamic>{
           'typename': instance.typename,
           'b': instance.b,
-          'self': instance.self,
+          'self': instance.self.toJson(),
           's': instance.s,
           '_s': instance.$_s,
         };
@@ -147,6 +147,6 @@ Map<String, dynamic>
         <String, dynamic>{
           'typename': instance.typename,
           'b': instance.b,
-          'self': instance.self,
+          'self': instance.self.toJson(),
           'i': instance.i,
         };

--- a/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI extends JsonSerializable {
   QueryFetchI({this.i1, required this.$__typename});
 
@@ -209,7 +209,7 @@ const QUERY_FETCH_I = const DocumentNode(definitions: [
       ])),
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1 extends JsonSerializable {
   QueryFetchI$i1({this.i2, required this.$__typename});
 
@@ -251,7 +251,7 @@ class QueryFetchI$i1 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$i2 extends JsonSerializable {
   QueryFetchI$i1$i2({this.field, required this.$__typename});
 
@@ -287,7 +287,7 @@ class QueryFetchI$i1$i2 extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$i2$field extends JsonSerializable {
   QueryFetchI$i1$i2$field({this.name, required this.$__typename});
 
@@ -323,7 +323,7 @@ class QueryFetchI$i1$i2$field extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1 extends JsonSerializable implements QueryFetchI$i1 {
   QueryFetchI$i1$T1({this.i2, required this.$__typename, this.i2c});
 
@@ -365,7 +365,7 @@ class QueryFetchI$i1$T1 extends JsonSerializable implements QueryFetchI$i1 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2c extends JsonSerializable {
   QueryFetchI$i1$T1$i2c({this.field, required this.$__typename});
 
@@ -401,7 +401,7 @@ class QueryFetchI$i1$T1$i2c extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2c$field extends JsonSerializable {
   QueryFetchI$i1$T1$i2c$field({this.age, required this.$__typename});
 
@@ -437,7 +437,7 @@ class QueryFetchI$i1$T1$i2c$field extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2 extends JsonSerializable
     implements QueryFetchI$i1$i2 {
   QueryFetchI$i1$T1$i2({this.field, required this.$__typename});
@@ -480,7 +480,7 @@ class QueryFetchI$i1$T1$i2 extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2$field extends JsonSerializable
     implements QueryFetchI$i1$i2$field {
   QueryFetchI$i1$T1$i2$field({this.name, required this.$__typename});
@@ -517,7 +517,7 @@ class QueryFetchI$i1$T1$i2$field extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2$T2 extends JsonSerializable
     implements QueryFetchI$i1$T1$i2 {
   QueryFetchI$i1$T1$i2$T2({this.field, required this.$__typename});
@@ -554,7 +554,7 @@ class QueryFetchI$i1$T1$i2$T2 extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2$T2$field extends JsonSerializable
     implements QueryFetchI$i1$T1$i2$field {
   QueryFetchI$i1$T1$i2$T2$field(

--- a/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
@@ -38,6 +38,13 @@ class QueryFetchI extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchI on QueryFetchI {
+  QueryFetchI copyWith({QueryFetchI$i1? Function()? i1, String? $__typename}) =>
+      QueryFetchI(
+          i1: i1 == null ? this.i1 : i1(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const QUERY_FETCH_I = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -251,6 +258,14 @@ class QueryFetchI$i1 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1 on QueryFetchI$i1 {
+  QueryFetchI$i1 copyWith(
+          {QueryFetchI$i1$i2? Function()? i2, String? $__typename}) =>
+      QueryFetchI$i1(
+          i2: i2 == null ? this.i2 : i2(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$i2 extends JsonSerializable {
   QueryFetchI$i1$i2({this.field, required this.$__typename});
@@ -287,6 +302,14 @@ class QueryFetchI$i1$i2 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1$i2 on QueryFetchI$i1$i2 {
+  QueryFetchI$i1$i2 copyWith(
+          {QueryFetchI$i1$i2$field? Function()? field, String? $__typename}) =>
+      QueryFetchI$i1$i2(
+          field: field == null ? this.field : field(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$i2$field extends JsonSerializable {
   QueryFetchI$i1$i2$field({this.name, required this.$__typename});
@@ -321,6 +344,14 @@ class QueryFetchI$i1$i2$field extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchI$i1$i2$field on QueryFetchI$i1$i2$field {
+  QueryFetchI$i1$i2$field copyWith(
+          {String? Function()? name, String? $__typename}) =>
+      QueryFetchI$i1$i2$field(
+          name: name == null ? this.name : name(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -365,6 +396,17 @@ class QueryFetchI$i1$T1 extends JsonSerializable implements QueryFetchI$i1 {
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1$T1 on QueryFetchI$i1$T1 {
+  QueryFetchI$i1$T1 copyWith(
+          {QueryFetchI$i1$T1$i2? Function()? i2,
+          String? $__typename,
+          QueryFetchI$i1$T1$i2c? Function()? i2c}) =>
+      QueryFetchI$i1$T1(
+          i2: i2 == null ? this.i2 : i2(),
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          i2c: i2c == null ? this.i2c : i2c());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2c extends JsonSerializable {
   QueryFetchI$i1$T1$i2c({this.field, required this.$__typename});
@@ -401,6 +443,15 @@ class QueryFetchI$i1$T1$i2c extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1$T1$i2c on QueryFetchI$i1$T1$i2c {
+  QueryFetchI$i1$T1$i2c copyWith(
+          {QueryFetchI$i1$T1$i2c$field? Function()? field,
+          String? $__typename}) =>
+      QueryFetchI$i1$T1$i2c(
+          field: field == null ? this.field : field(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2c$field extends JsonSerializable {
   QueryFetchI$i1$T1$i2c$field({this.age, required this.$__typename});
@@ -435,6 +486,15 @@ class QueryFetchI$i1$T1$i2c$field extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchI$i1$T1$i2c$field
+    on QueryFetchI$i1$T1$i2c$field {
+  QueryFetchI$i1$T1$i2c$field copyWith(
+          {int? Function()? age, String? $__typename}) =>
+      QueryFetchI$i1$T1$i2c$field(
+          age: age == null ? this.age : age(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -480,6 +540,15 @@ class QueryFetchI$i1$T1$i2 extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1$T1$i2 on QueryFetchI$i1$T1$i2 {
+  QueryFetchI$i1$T1$i2 copyWith(
+          {QueryFetchI$i1$T1$i2$field? Function()? field,
+          String? $__typename}) =>
+      QueryFetchI$i1$T1$i2(
+          field: field == null ? this.field : field(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2$field extends JsonSerializable
     implements QueryFetchI$i1$i2$field {
@@ -517,6 +586,15 @@ class QueryFetchI$i1$T1$i2$field extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryFetchI$i1$T1$i2$field
+    on QueryFetchI$i1$T1$i2$field {
+  QueryFetchI$i1$T1$i2$field copyWith(
+          {String? Function()? name, String? $__typename}) =>
+      QueryFetchI$i1$T1$i2$field(
+          name: name == null ? this.name : name(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchI$i1$T1$i2$T2 extends JsonSerializable
     implements QueryFetchI$i1$T1$i2 {
@@ -552,6 +630,15 @@ class QueryFetchI$i1$T1$i2$T2 extends JsonSerializable
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchI$i1$T1$i2$T2 on QueryFetchI$i1$T1$i2$T2 {
+  QueryFetchI$i1$T1$i2$T2 copyWith(
+          {QueryFetchI$i1$T1$i2$T2$field? Function()? field,
+          String? $__typename}) =>
+      QueryFetchI$i1$T1$i2$T2(
+          field: field == null ? this.field : field(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -596,6 +683,18 @@ class QueryFetchI$i1$T1$i2$T2$field extends JsonSerializable
     if (l$age != lOther$age) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchI$i1$T1$i2$T2$field
+    on QueryFetchI$i1$T1$i2$T2$field {
+  QueryFetchI$i1$T1$i2$T2$field copyWith(
+          {String? Function()? name,
+          String? $__typename,
+          int? Function()? age}) =>
+      QueryFetchI$i1$T1$i2$T2$field(
+          name: name == null ? this.name : name(),
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          age: age == null ? this.age : age());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.g.dart
@@ -15,7 +15,7 @@ QueryFetchI _$QueryFetchIFromJson(Map<String, dynamic> json) => QueryFetchI(
 
 Map<String, dynamic> _$QueryFetchIToJson(QueryFetchI instance) =>
     <String, dynamic>{
-      'i1': instance.i1,
+      'i1': instance.i1?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -29,7 +29,7 @@ QueryFetchI$i1 _$QueryFetchI$i1FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchI$i1ToJson(QueryFetchI$i1 instance) =>
     <String, dynamic>{
-      'i2': instance.i2,
+      'i2': instance.i2?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -44,7 +44,7 @@ QueryFetchI$i1$i2 _$QueryFetchI$i1$i2FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchI$i1$i2ToJson(QueryFetchI$i1$i2 instance) =>
     <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -75,9 +75,9 @@ QueryFetchI$i1$T1 _$QueryFetchI$i1$T1FromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchI$i1$T1ToJson(QueryFetchI$i1$T1 instance) =>
     <String, dynamic>{
-      'i2': instance.i2,
+      'i2': instance.i2?.toJson(),
       '__typename': instance.$__typename,
-      'i2c': instance.i2c,
+      'i2c': instance.i2c?.toJson(),
     };
 
 QueryFetchI$i1$T1$i2c _$QueryFetchI$i1$T1$i2cFromJson(
@@ -93,7 +93,7 @@ QueryFetchI$i1$T1$i2c _$QueryFetchI$i1$T1$i2cFromJson(
 Map<String, dynamic> _$QueryFetchI$i1$T1$i2cToJson(
         QueryFetchI$i1$T1$i2c instance) =>
     <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -124,7 +124,7 @@ QueryFetchI$i1$T1$i2 _$QueryFetchI$i1$T1$i2FromJson(
 Map<String, dynamic> _$QueryFetchI$i1$T1$i2ToJson(
         QueryFetchI$i1$T1$i2 instance) =>
     <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -155,7 +155,7 @@ QueryFetchI$i1$T1$i2$T2 _$QueryFetchI$i1$T1$i2$T2FromJson(
 Map<String, dynamic> _$QueryFetchI$i1$T1$i2$T2ToJson(
         QueryFetchI$i1$T1$i2$T2 instance) =>
     <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
@@ -44,6 +44,17 @@ class FragmentFragmentA extends JsonSerializable implements FragmentFragmentI {
   }
 }
 
+extension UtilityExtensionFragmentFragmentA on FragmentFragmentA {
+  FragmentFragmentA copyWith(
+          {String? $__typename,
+          String? Function()? value,
+          String? Function()? name}) =>
+      FragmentFragmentA(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          value: value == null ? this.value : value(),
+          name: name == null ? this.name : name());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_A = const FragmentDefinitionNode(
     name: NameNode(value: 'FragmentA'),
     typeCondition: TypeConditionNode(
@@ -105,6 +116,13 @@ class FragmentFragmentI extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentFragmentI on FragmentFragmentI {
+  FragmentFragmentI copyWith({String? $__typename, String? Function()? name}) =>
+      FragmentFragmentI(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_I = const FragmentDefinitionNode(
     name: NameNode(value: 'FragmentI'),
     typeCondition: TypeConditionNode(
@@ -162,6 +180,14 @@ class QueryFetchStuff extends JsonSerializable {
     if (l$field != lOther$field) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchStuff on QueryFetchStuff {
+  QueryFetchStuff copyWith(
+          {String? $__typename, QueryFetchStuff$field? Function()? field}) =>
+      QueryFetchStuff(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          field: field == null ? this.field : field());
 }
 
 const QUERY_FETCH_STUFF = const DocumentNode(definitions: [
@@ -284,6 +310,14 @@ class QueryFetchStuff$field extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchStuff$field on QueryFetchStuff$field {
+  QueryFetchStuff$field copyWith(
+          {String? $__typename, String? Function()? name}) =>
+      QueryFetchStuff$field(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryFetchStuff$field$FieldA extends JsonSerializable
     implements FragmentFragmentA, FragmentFragmentI, QueryFetchStuff$field {
@@ -326,6 +360,18 @@ class QueryFetchStuff$field$FieldA extends JsonSerializable
     if (l$value != lOther$value) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchStuff$field$FieldA
+    on QueryFetchStuff$field$FieldA {
+  QueryFetchStuff$field$FieldA copyWith(
+          {String? $__typename,
+          String? Function()? name,
+          String? Function()? value}) =>
+      QueryFetchStuff$field$FieldA(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name(),
+          value: value == null ? this.value : value());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentFragmentA extends JsonSerializable implements FragmentFragmentI {
   FragmentFragmentA({required this.$__typename, this.value, this.name});
 
@@ -69,7 +69,7 @@ const FRAGMENT_FRAGMENT_A = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_I,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentFragmentI extends JsonSerializable {
   FragmentFragmentI({required this.$__typename, this.name});
 
@@ -128,7 +128,7 @@ const FRAGMENT_FRAGMENT_I = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_I,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchStuff extends JsonSerializable {
   QueryFetchStuff({required this.$__typename, this.field});
 
@@ -242,7 +242,7 @@ const QUERY_FETCH_STUFF = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_FRAGMENT_I,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchStuff$field extends JsonSerializable {
   QueryFetchStuff$field({required this.$__typename, this.name});
 
@@ -284,7 +284,7 @@ class QueryFetchStuff$field extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchStuff$field$FieldA extends JsonSerializable
     implements FragmentFragmentA, FragmentFragmentI, QueryFetchStuff$field {
   QueryFetchStuff$field$FieldA(

--- a/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.g.dart
@@ -44,7 +44,7 @@ QueryFetchStuff _$QueryFetchStuffFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$QueryFetchStuffToJson(QueryFetchStuff instance) =>
     <String, dynamic>{
       '__typename': instance.$__typename,
-      'field': instance.field,
+      'field': instance.field?.toJson(),
     };
 
 QueryFetchStuff$field _$QueryFetchStuff$fieldFromJson(

--- a/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
@@ -31,6 +31,11 @@ class FragmentF0 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF0 on FragmentF0 {
+  FragmentF0 copyWith({String? Function()? name01}) =>
+      FragmentF0(name01: name01 == null ? this.name01 : name01());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F0 = const FragmentDefinitionNode(
     name: NameNode(value: 'F0'),
     typeCondition: TypeConditionNode(
@@ -75,6 +80,11 @@ class FragmentF1 extends JsonSerializable {
     if (l$size2 != lOther$size2) return false;
     return true;
   }
+}
+
+extension UtilityExtensionFragmentF1 on FragmentF1 {
+  FragmentF1 copyWith({int? Function()? size2}) =>
+      FragmentF1(size2: size2 == null ? this.size2 : size2());
 }
 
 const FRAGMENT_DEFINITION_FRAGMENT_F1 = const FragmentDefinitionNode(
@@ -123,6 +133,11 @@ class FragmentF2 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF2 on FragmentF2 {
+  FragmentF2 copyWith({String? Function()? name2}) =>
+      FragmentF2(name2: name2 == null ? this.name2 : name2());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F2 = const FragmentDefinitionNode(
     name: NameNode(value: 'F2'),
     typeCondition: TypeConditionNode(
@@ -169,6 +184,11 @@ class FragmentF3 extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF3 on FragmentF3 {
+  FragmentF3 copyWith({double? Function()? value}) =>
+      FragmentF3(value: value == null ? this.value : value());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F3 = const FragmentDefinitionNode(
     name: NameNode(value: 'F3'),
     typeCondition: TypeConditionNode(
@@ -211,6 +231,11 @@ class QueryQ extends JsonSerializable {
     if (l$field != lOther$field) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$field? Function()? field}) =>
+      QueryQ(field: field == null ? this.field : field());
 }
 
 const QUERY_Q = const DocumentNode(definitions: [
@@ -344,6 +369,17 @@ class QueryQ$field extends JsonSerializable implements FragmentF0 {
   }
 }
 
+extension UtilityExtensionQueryQ$field on QueryQ$field {
+  QueryQ$field copyWith(
+          {String? $__typename,
+          String? Function()? name0,
+          String? Function()? name01}) =>
+      QueryQ$field(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name0: name0 == null ? this.name0 : name0(),
+          name01: name01 == null ? this.name01 : name01());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$field$T1 extends JsonSerializable
     implements FragmentF1, FragmentF2, QueryQ$field {
@@ -417,6 +453,25 @@ class QueryQ$field$T1 extends JsonSerializable
     if (l$name2 != lOther$name2) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$field$T1 on QueryQ$field$T1 {
+  QueryQ$field$T1 copyWith(
+          {String? $__typename,
+          String? Function()? name0,
+          String? Function()? name01,
+          int? Function()? size,
+          String? Function()? name,
+          int? Function()? size2,
+          String? Function()? name2}) =>
+      QueryQ$field$T1(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name0: name0 == null ? this.name0 : name0(),
+          name01: name01 == null ? this.name01 : name01(),
+          size: size == null ? this.size : size(),
+          name: name == null ? this.name : name(),
+          size2: size2 == null ? this.size2 : size2(),
+          name2: name2 == null ? this.name2 : name2());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF0 extends JsonSerializable {
   FragmentF0({this.name01});
 
@@ -48,7 +48,7 @@ const FRAGMENT_F0 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F0,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF1 extends JsonSerializable {
   FragmentF1({this.size2});
 
@@ -94,7 +94,7 @@ const FRAGMENT_F1 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F1,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF2 extends JsonSerializable {
   FragmentF2({this.name2});
 
@@ -140,7 +140,7 @@ const FRAGMENT_F2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F2,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF3 extends JsonSerializable {
   FragmentF3({this.value});
 
@@ -186,7 +186,7 @@ const FRAGMENT_F3 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F3,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.field});
 
@@ -296,7 +296,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F3,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$field extends JsonSerializable implements FragmentF0 {
   QueryQ$field({required this.$__typename, this.name0, this.name01});
 
@@ -344,7 +344,7 @@ class QueryQ$field extends JsonSerializable implements FragmentF0 {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$field$T1 extends JsonSerializable
     implements FragmentF1, FragmentF2, QueryQ$field {
   QueryQ$field$T1(

--- a/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.g.dart
@@ -49,7 +49,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
     };
 
 QueryQ$field _$QueryQ$fieldFromJson(Map<String, dynamic> json) => QueryQ$field(

--- a/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
@@ -30,6 +30,11 @@ class FragmentF extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF on FragmentF {
+  FragmentF copyWith({FragmentF$t? Function()? t}) =>
+      FragmentF(t: t == null ? this.t : t());
+}
+
 const FRAGMENT_DEFINITION_FRAGMENT_F = const FragmentDefinitionNode(
     name: NameNode(value: 'F'),
     typeCondition: TypeConditionNode(
@@ -90,6 +95,11 @@ class FragmentF$t extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF$t on FragmentF$t {
+  FragmentF$t copyWith({FragmentF$t$t? Function()? t}) =>
+      FragmentF$t(t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class FragmentF$t$t extends JsonSerializable {
   FragmentF$t$t({required this.$__typename});
@@ -120,6 +130,11 @@ class FragmentF$t$t extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionFragmentF$t$t on FragmentF$t$t {
+  FragmentF$t$t copyWith({String? $__typename}) => FragmentF$t$t(
+      $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
@@ -145,6 +160,11 @@ class QueryQ extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$t? Function()? t}) =>
+      QueryQ(t: t == null ? this.t : t());
 }
 
 const QUERY_Q = const DocumentNode(definitions: [
@@ -223,6 +243,11 @@ class QueryQ$t extends JsonSerializable implements FragmentF {
   }
 }
 
+extension UtilityExtensionQueryQ$t on QueryQ$t {
+  QueryQ$t copyWith({QueryQ$t$t? Function()? t}) =>
+      QueryQ$t(t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable implements FragmentF, FragmentF$t {
   QueryQ$t$t({this.t});
@@ -250,6 +275,11 @@ class QueryQ$t$t extends JsonSerializable implements FragmentF, FragmentF$t {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$t$t on QueryQ$t$t {
+  QueryQ$t$t copyWith({QueryQ$t$t$t? Function()? t}) =>
+      QueryQ$t$t(t: t == null ? this.t : t());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -289,6 +319,13 @@ class QueryQ$t$t$t extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryQ$t$t$t on QueryQ$t$t$t {
+  QueryQ$t$t$t copyWith({QueryQ$t$t$t$t? Function()? t, String? $__typename}) =>
+      QueryQ$t$t$t(
+          t: t == null ? this.t : t(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   QueryQ$t$t$t$t({required this.$__typename});
@@ -319,6 +356,11 @@ class QueryQ$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   }
 }
 
+extension UtilityExtensionQueryQ$t$t$t$t on QueryQ$t$t$t$t {
+  QueryQ$t$t$t$t copyWith({String? $__typename}) => QueryQ$t$t$t$t(
+      $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ2 extends JsonSerializable {
   QueryQ2({this.t});
@@ -345,6 +387,11 @@ class QueryQ2 extends JsonSerializable {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ2 on QueryQ2 {
+  QueryQ2 copyWith({QueryQ2$t? Function()? t}) =>
+      QueryQ2(t: t == null ? this.t : t());
 }
 
 const QUERY_Q2 = const DocumentNode(definitions: [
@@ -423,6 +470,11 @@ class QueryQ2$t extends JsonSerializable implements FragmentF {
   }
 }
 
+extension UtilityExtensionQueryQ2$t on QueryQ2$t {
+  QueryQ2$t copyWith({QueryQ2$t$t? Function()? t}) =>
+      QueryQ2$t(t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ2$t$t extends JsonSerializable implements FragmentF$t, FragmentF {
   QueryQ2$t$t({this.t});
@@ -450,6 +502,11 @@ class QueryQ2$t$t extends JsonSerializable implements FragmentF$t, FragmentF {
     if (l$t != lOther$t) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ2$t$t on QueryQ2$t$t {
+  QueryQ2$t$t copyWith({QueryQ2$t$t$t? Function()? t}) =>
+      QueryQ2$t$t(t: t == null ? this.t : t());
 }
 
 @JsonSerializable(explicitToJson: true)
@@ -489,6 +546,14 @@ class QueryQ2$t$t$t extends JsonSerializable
   }
 }
 
+extension UtilityExtensionQueryQ2$t$t$t on QueryQ2$t$t$t {
+  QueryQ2$t$t$t copyWith(
+          {String? $__typename, QueryQ2$t$t$t$t? Function()? t}) =>
+      QueryQ2$t$t$t(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          t: t == null ? this.t : t());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ2$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   QueryQ2$t$t$t$t({required this.$__typename});
@@ -517,6 +582,11 @@ class QueryQ2$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ2$t$t$t$t on QueryQ2$t$t$t$t {
+  QueryQ2$t$t$t$t copyWith({String? $__typename}) => QueryQ2$t$t$t$t(
+      $__typename: $__typename == null ? this.$__typename : $__typename);
 }
 
 const POSSIBLE_TYPES_MAP = const {};

--- a/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF extends JsonSerializable {
   FragmentF({this.t});
 
@@ -61,7 +61,7 @@ const FRAGMENT_F = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$t extends JsonSerializable {
   FragmentF$t({this.t});
 
@@ -90,7 +90,7 @@ class FragmentF$t extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class FragmentF$t$t extends JsonSerializable {
   FragmentF$t$t({required this.$__typename});
 
@@ -120,7 +120,7 @@ class FragmentF$t$t extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.t});
 
@@ -195,7 +195,7 @@ const QUERY_Q = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t extends JsonSerializable implements FragmentF {
   QueryQ$t({this.t});
 
@@ -223,7 +223,7 @@ class QueryQ$t extends JsonSerializable implements FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t$t extends JsonSerializable implements FragmentF, FragmentF$t {
   QueryQ$t$t({this.t});
 
@@ -252,7 +252,7 @@ class QueryQ$t$t extends JsonSerializable implements FragmentF, FragmentF$t {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t$t$t extends JsonSerializable
     implements FragmentF$t, FragmentF$t$t {
   QueryQ$t$t$t({this.t, required this.$__typename});
@@ -289,7 +289,7 @@ class QueryQ$t$t$t extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   QueryQ$t$t$t$t({required this.$__typename});
 
@@ -319,7 +319,7 @@ class QueryQ$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ2 extends JsonSerializable {
   QueryQ2({this.t});
 
@@ -395,7 +395,7 @@ const QUERY_Q2 = const DocumentNode(definitions: [
   FRAGMENT_DEFINITION_FRAGMENT_F,
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ2$t extends JsonSerializable implements FragmentF {
   QueryQ2$t({this.t});
 
@@ -423,7 +423,7 @@ class QueryQ2$t extends JsonSerializable implements FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ2$t$t extends JsonSerializable implements FragmentF$t, FragmentF {
   QueryQ2$t$t({this.t});
 
@@ -452,7 +452,7 @@ class QueryQ2$t$t extends JsonSerializable implements FragmentF$t, FragmentF {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ2$t$t$t extends JsonSerializable
     implements FragmentF$t$t, FragmentF$t {
   QueryQ2$t$t$t({required this.$__typename, this.t});
@@ -489,7 +489,7 @@ class QueryQ2$t$t$t extends JsonSerializable
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ2$t$t$t$t extends JsonSerializable implements FragmentF$t$t {
   QueryQ2$t$t$t$t({required this.$__typename});
 

--- a/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.g.dart
@@ -13,7 +13,7 @@ FragmentF _$FragmentFFromJson(Map<String, dynamic> json) => FragmentF(
     );
 
 Map<String, dynamic> _$FragmentFToJson(FragmentF instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 FragmentF$t _$FragmentF$tFromJson(Map<String, dynamic> json) => FragmentF$t(
@@ -24,7 +24,7 @@ FragmentF$t _$FragmentF$tFromJson(Map<String, dynamic> json) => FragmentF$t(
 
 Map<String, dynamic> _$FragmentF$tToJson(FragmentF$t instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 FragmentF$t$t _$FragmentF$t$tFromJson(Map<String, dynamic> json) =>
@@ -44,7 +44,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
@@ -54,7 +54,7 @@ QueryQ$t _$QueryQ$tFromJson(Map<String, dynamic> json) => QueryQ$t(
     );
 
 Map<String, dynamic> _$QueryQ$tToJson(QueryQ$t instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t$t _$QueryQ$t$tFromJson(Map<String, dynamic> json) => QueryQ$t$t(
@@ -65,7 +65,7 @@ QueryQ$t$t _$QueryQ$t$tFromJson(Map<String, dynamic> json) => QueryQ$t$t(
 
 Map<String, dynamic> _$QueryQ$t$tToJson(QueryQ$t$t instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ$t$t$t _$QueryQ$t$t$tFromJson(Map<String, dynamic> json) => QueryQ$t$t$t(
@@ -77,7 +77,7 @@ QueryQ$t$t$t _$QueryQ$t$t$tFromJson(Map<String, dynamic> json) => QueryQ$t$t$t(
 
 Map<String, dynamic> _$QueryQ$t$t$tToJson(QueryQ$t$t$t instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
       '__typename': instance.$__typename,
     };
 
@@ -98,7 +98,7 @@ QueryQ2 _$QueryQ2FromJson(Map<String, dynamic> json) => QueryQ2(
     );
 
 Map<String, dynamic> _$QueryQ2ToJson(QueryQ2 instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ2$t _$QueryQ2$tFromJson(Map<String, dynamic> json) => QueryQ2$t(
@@ -108,7 +108,7 @@ QueryQ2$t _$QueryQ2$tFromJson(Map<String, dynamic> json) => QueryQ2$t(
     );
 
 Map<String, dynamic> _$QueryQ2$tToJson(QueryQ2$t instance) => <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ2$t$t _$QueryQ2$t$tFromJson(Map<String, dynamic> json) => QueryQ2$t$t(
@@ -119,7 +119,7 @@ QueryQ2$t$t _$QueryQ2$t$tFromJson(Map<String, dynamic> json) => QueryQ2$t$t(
 
 Map<String, dynamic> _$QueryQ2$t$tToJson(QueryQ2$t$t instance) =>
     <String, dynamic>{
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ2$t$t$t _$QueryQ2$t$t$tFromJson(Map<String, dynamic> json) =>
@@ -133,7 +133,7 @@ QueryQ2$t$t$t _$QueryQ2$t$t$tFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$QueryQ2$t$t$tToJson(QueryQ2$t$t$t instance) =>
     <String, dynamic>{
       '__typename': instance.$__typename,
-      't': instance.t,
+      't': instance.t?.toJson(),
     };
 
 QueryQ2$t$t$t$t _$QueryQ2$t$t$t$tFromJson(Map<String, dynamic> json) =>

--- a/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
@@ -91,6 +91,25 @@ class QueryFetchScalars extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchScalars on QueryFetchScalars {
+  QueryFetchScalars copyWith(
+          {int? Function()? i,
+          int? Function()? id,
+          String? Function()? s,
+          String? Function()? c1,
+          DateTime? Function()? c2,
+          Fobbob? Function()? c3,
+          List<Fobbob?>? Function()? c3s}) =>
+      QueryFetchScalars(
+          i: i == null ? this.i : i(),
+          id: id == null ? this.id : id(),
+          s: s == null ? this.s : s(),
+          c1: c1 == null ? this.c1 : c1(),
+          c2: c2 == null ? this.c2 : c2(),
+          c3: c3 == null ? this.c3 : c3(),
+          c3s: c3s == null ? this.c3s : c3s());
+}
+
 const QUERY_FETCH_SCALARS = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,

--- a/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'scalar_import.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchScalars extends JsonSerializable {
   QueryFetchScalars(
       {this.i, this.id, this.s, this.c1, this.c2, this.c3, this.c3s});

--- a/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
@@ -39,6 +39,15 @@ class QueryFetchPerson extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchPerson on QueryFetchPerson {
+  QueryFetchPerson copyWith(
+          {QueryFetchPerson$fetchPerson? Function()? fetchPerson,
+          String? $__typename}) =>
+      QueryFetchPerson(
+          fetchPerson: fetchPerson == null ? this.fetchPerson : fetchPerson(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -122,4 +131,16 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchPerson$fetchPerson
+    on QueryFetchPerson$fetchPerson {
+  QueryFetchPerson$fetchPerson copyWith(
+          {String? Function()? name,
+          EnumStatus? status,
+          String? $__typename}) =>
+      QueryFetchPerson$fetchPerson(
+          name: name == null ? this.name : name(),
+          status: status == null ? this.status : status,
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }

--- a/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
@@ -3,7 +3,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'a.query.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson extends JsonSerializable {
   QueryFetchPerson({this.fetchPerson, required this.$__typename});
 
@@ -80,7 +80,7 @@ const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
       ])),
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson extends JsonSerializable {
   QueryFetchPerson$fetchPerson(
       {this.name, required this.status, required this.$__typename});

--- a/packages/graphql_codegen/test/assets/scopes/a.query.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/scopes/a.query.graphql.g.dart
@@ -17,7 +17,7 @@ QueryFetchPerson _$QueryFetchPersonFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchPersonToJson(QueryFetchPerson instance) =>
     <String, dynamic>{
-      'fetchPerson': instance.fetchPerson,
+      'fetchPerson': instance.fetchPerson?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
@@ -39,6 +39,15 @@ class QueryFetchPerson extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryFetchPerson on QueryFetchPerson {
+  QueryFetchPerson copyWith(
+          {QueryFetchPerson$fetchPerson? Function()? fetchPerson,
+          String? $__typename}) =>
+      QueryFetchPerson(
+          fetchPerson: fetchPerson == null ? this.fetchPerson : fetchPerson(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -134,4 +143,18 @@ class QueryFetchPerson$fetchPerson extends JsonSerializable {
     if (l$$__typename != lOther$$__typename) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryFetchPerson$fetchPerson
+    on QueryFetchPerson$fetchPerson {
+  QueryFetchPerson$fetchPerson copyWith(
+          {int? Function()? age,
+          String? Function()? name,
+          EnumStatus? Function()? status,
+          String? $__typename}) =>
+      QueryFetchPerson$fetchPerson(
+          age: age == null ? this.age : age(),
+          name: name == null ? this.name : name(),
+          status: status == null ? this.status : status(),
+          $__typename: $__typename == null ? this.$__typename : $__typename);
 }

--- a/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
@@ -3,7 +3,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'b.query.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson extends JsonSerializable {
   QueryFetchPerson({this.fetchPerson, required this.$__typename});
 
@@ -86,7 +86,7 @@ const QUERY_FETCH_PERSON = const DocumentNode(definitions: [
       ])),
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryFetchPerson$fetchPerson extends JsonSerializable {
   QueryFetchPerson$fetchPerson(
       {this.age, this.name, this.status, required this.$__typename});

--- a/packages/graphql_codegen/test/assets/scopes/b.query.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/scopes/b.query.graphql.g.dart
@@ -17,7 +17,7 @@ QueryFetchPerson _$QueryFetchPersonFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$QueryFetchPersonToJson(QueryFetchPerson instance) =>
     <String, dynamic>{
-      'fetchPerson': instance.fetchPerson,
+      'fetchPerson': instance.fetchPerson?.toJson(),
       '__typename': instance.$__typename,
     };
 

--- a/packages/graphql_codegen/test/assets/unions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/unions/document.graphql.dart
@@ -29,6 +29,11 @@ class QueryQ extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryQ on QueryQ {
+  QueryQ copyWith({QueryQ$u? Function()? u}) =>
+      QueryQ(u: u == null ? this.u : u());
+}
+
 const QUERY_Q = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -115,6 +120,11 @@ class QueryQ$u extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryQ$u on QueryQ$u {
+  QueryQ$u copyWith({String? $__typename}) => QueryQ$u(
+      $__typename: $__typename == null ? this.$__typename : $__typename);
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$u$Ta extends JsonSerializable implements QueryQ$u {
   QueryQ$u$Ta({required this.$__typename, this.name});
@@ -151,6 +161,13 @@ class QueryQ$u$Ta extends JsonSerializable implements QueryQ$u {
   }
 }
 
+extension UtilityExtensionQueryQ$u$Ta on QueryQ$u$Ta {
+  QueryQ$u$Ta copyWith({String? $__typename, String? Function()? name}) =>
+      QueryQ$u$Ta(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          name: name == null ? this.name : name());
+}
+
 @JsonSerializable(explicitToJson: true)
 class QueryQ$u$Tb extends JsonSerializable implements QueryQ$u {
   QueryQ$u$Tb({required this.$__typename, this.velocity});
@@ -185,6 +202,13 @@ class QueryQ$u$Tb extends JsonSerializable implements QueryQ$u {
     if (l$velocity != lOther$velocity) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryQ$u$Tb on QueryQ$u$Tb {
+  QueryQ$u$Tb copyWith({String? $__typename, int? Function()? velocity}) =>
+      QueryQ$u$Tb(
+          $__typename: $__typename == null ? this.$__typename : $__typename,
+          velocity: velocity == null ? this.velocity : velocity());
 }
 
 const POSSIBLE_TYPES_MAP = const {

--- a/packages/graphql_codegen/test/assets/unions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/unions/document.graphql.dart
@@ -2,7 +2,7 @@ import 'package:gql/ast.dart';
 import 'package:json_annotation/json_annotation.dart';
 part 'document.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ extends JsonSerializable {
   QueryQ({this.u});
 
@@ -78,7 +78,7 @@ const QUERY_Q = const DocumentNode(definitions: [
       ])),
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$u extends JsonSerializable {
   QueryQ$u({required this.$__typename});
 
@@ -115,7 +115,7 @@ class QueryQ$u extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$u$Ta extends JsonSerializable implements QueryQ$u {
   QueryQ$u$Ta({required this.$__typename, this.name});
 
@@ -151,7 +151,7 @@ class QueryQ$u$Ta extends JsonSerializable implements QueryQ$u {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryQ$u$Tb extends JsonSerializable implements QueryQ$u {
   QueryQ$u$Tb({required this.$__typename, this.velocity});
 

--- a/packages/graphql_codegen/test/assets/unions/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/unions/document.graphql.g.dart
@@ -13,7 +13,7 @@ QueryQ _$QueryQFromJson(Map<String, dynamic> json) => QueryQ(
     );
 
 Map<String, dynamic> _$QueryQToJson(QueryQ instance) => <String, dynamic>{
-      'u': instance.u,
+      'u': instance.u?.toJson(),
     };
 
 QueryQ$u _$QueryQ$uFromJson(Map<String, dynamic> json) => QueryQ$u(

--- a/packages/graphql_codegen/test/assets/variables/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/variables/schema.graphql.dart
@@ -1,7 +1,7 @@
 import 'package:json_annotation/json_annotation.dart';
 part 'schema.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class InputI1 extends JsonSerializable {
   InputI1({required this.s, this.nested});
 

--- a/packages/graphql_codegen/test/assets/variables/schema.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/variables/schema.graphql.g.dart
@@ -15,5 +15,5 @@ InputI1 _$InputI1FromJson(Map<String, dynamic> json) => InputI1(
 
 Map<String, dynamic> _$InputI1ToJson(InputI1 instance) => <String, dynamic>{
       's': instance.s,
-      'nested': instance.nested,
+      'nested': instance.nested?.toJson(),
     };

--- a/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
+++ b/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
@@ -61,6 +61,11 @@ class QueryHiBob extends JsonSerializable {
   }
 }
 
+extension UtilityExtensionQueryHiBob on QueryHiBob {
+  QueryHiBob copyWith({QueryHiBob$field? Function()? field}) =>
+      QueryHiBob(field: field == null ? this.field : field());
+}
+
 const QUERY_HI_BOB = const DocumentNode(definitions: [
   OperationDefinitionNode(
       type: OperationType.query,
@@ -124,4 +129,9 @@ class QueryHiBob$field extends JsonSerializable {
     if (l$value != lOther$value) return false;
     return true;
   }
+}
+
+extension UtilityExtensionQueryHiBob$field on QueryHiBob$field {
+  QueryHiBob$field copyWith({String? value}) =>
+      QueryHiBob$field(value: value == null ? this.value : value);
 }

--- a/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
+++ b/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 import 'schema.graphql.dart';
 part 'variables.graphql.g.dart';
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class VariablesQueryHiBob extends JsonSerializable {
   VariablesQueryHiBob({required this.i});
 
@@ -32,7 +32,7 @@ class VariablesQueryHiBob extends JsonSerializable {
   }
 }
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryHiBob extends JsonSerializable {
   QueryHiBob({this.field});
 
@@ -97,7 +97,7 @@ const QUERY_HI_BOB = const DocumentNode(definitions: [
       ])),
 ]);
 
-@JsonSerializable()
+@JsonSerializable(explicitToJson: true)
 class QueryHiBob$field extends JsonSerializable {
   QueryHiBob$field({required this.value});
 

--- a/packages/graphql_codegen/test/assets/variables/variables.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/variables/variables.graphql.g.dart
@@ -14,7 +14,7 @@ VariablesQueryHiBob _$VariablesQueryHiBobFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$VariablesQueryHiBobToJson(
         VariablesQueryHiBob instance) =>
     <String, dynamic>{
-      'i': instance.i,
+      'i': instance.i.toJson(),
     };
 
 QueryHiBob _$QueryHiBobFromJson(Map<String, dynamic> json) => QueryHiBob(
@@ -25,7 +25,7 @@ QueryHiBob _$QueryHiBobFromJson(Map<String, dynamic> json) => QueryHiBob(
 
 Map<String, dynamic> _$QueryHiBobToJson(QueryHiBob instance) =>
     <String, dynamic>{
-      'field': instance.field,
+      'field': instance.field?.toJson(),
     };
 
 QueryHiBob$field _$QueryHiBob$fieldFromJson(Map<String, dynamic> json) =>


### PR DESCRIPTION
This PR contains:

* JSON serializable explicitly call `toJson`
* New utility extension on to allow copying fragment and query classes.