### PR TITLE
fix: Generate operation with single fragment

### DIFF
--- a/packages/graphql_codegen/CHANGELOG.md
+++ b/packages/graphql_codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.10.0-beta.6
+
+* Fix not generating Operations with single fragment
+
+
 # 0.10.0-beta.5
 
 * Fixes broken paths on windows

--- a/packages/graphql_codegen/lib/src/context.dart
+++ b/packages/graphql_codegen/lib/src/context.dart
@@ -143,6 +143,8 @@ class ContextFragment<TKey extends Object>
 
   @override
   NameNode get currentTypeName => currentType.name;
+
+  bool get isDefinitionContext => fragment != null;
 }
 
 const _BUILT_IN_SCALARS = const DocumentNode(definitions: [
@@ -647,6 +649,8 @@ abstract class Context<TKey extends Object, TType extends TypeDefinitionNode> {
     _fragmentDependencies.add(fragmentDefinitionNode);
   }
 
+  bool get isDefinitionContext;
+
   Iterable<ContextProperty> get properties => _properties.values;
 
   Iterable<ContextProperty> get variables => _variables.values;
@@ -690,6 +694,7 @@ abstract class Context<TKey extends Object, TType extends TypeDefinitionNode> {
       replacementContext ?? this;
 
   Context<TKey, TypeDefinitionNode>? get replacementContext {
+    if (isDefinitionContext) return null;
     final parentReplace = parent?.replacementContext;
     if (parentReplace != null) {
       final newName = parentReplace.path.withSegment(path.segments.last);
@@ -765,6 +770,8 @@ class ContextRoot<TKey extends Object>
         false;
   }
 
+  final bool isDefinitionContext = false;
+
   Map<String, Set<String>> get possibleTypesMap {
     final possibleTypes = <String, Set<NameNode>>{};
     for (final definition in schema.definitions) {
@@ -815,6 +822,8 @@ class ContextEnum<TKey extends Object>
 
   @override
   NameNode get currentTypeName => currentType.name;
+
+  final bool isDefinitionContext = true;
 }
 
 class ContextInput<TKey extends Object>
@@ -837,6 +846,8 @@ class ContextInput<TKey extends Object>
         );
   @override
   NameNode get currentTypeName => currentType.name;
+
+  final bool isDefinitionContext = true;
 }
 
 class ContextOperation<TKey extends Object>
@@ -912,6 +923,8 @@ class ContextOperation<TKey extends Object>
 
   @override
   NameNode get currentTypeName => currentType.name;
+
+  bool get isDefinitionContext => operation != null;
 }
 
 class Name {

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -3,7 +3,7 @@ description: |
   Simple, opinionated, codegen library for GraphQL. It allows you to
   generate serializers and client helpers to easily call and parse your data.
 
-version: 0.10.0-beta.5
+version: 0.10.0-beta.6
 homepage: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 repository: https://github.com/heftapp/graphql_codegen/tree/main/packages/graphql_codegen
 

--- a/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql
+++ b/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql
@@ -1,0 +1,12 @@
+query Q {
+    ...F
+}
+
+fragment F on Query {
+    name
+}
+
+
+type Query {
+    name: String
+}

--- a/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.dart
@@ -1,0 +1,192 @@
+import 'package:gql/ast.dart';
+import 'package:json_annotation/json_annotation.dart';
+part 'document.graphql.g.dart';
+
+@JsonSerializable(explicitToJson: true)
+class Fragment$F {
+  Fragment$F({this.name, required this.$__typename});
+
+  @override
+  factory Fragment$F.fromJson(Map<String, dynamic> json) =>
+      _$Fragment$FFromJson(json);
+
+  final String? name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  Map<String, dynamic> toJson() => _$Fragment$FToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is Fragment$F) || runtimeType != other.runtimeType)
+      return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    return true;
+  }
+}
+
+extension UtilityExtension$Fragment$F on Fragment$F {
+  CopyWith$Fragment$F<Fragment$F> get copyWith =>
+      CopyWith$Fragment$F(this, (i) => i);
+}
+
+abstract class CopyWith$Fragment$F<TRes> {
+  factory CopyWith$Fragment$F(
+          Fragment$F instance, TRes Function(Fragment$F) then) =
+      _CopyWithImpl$Fragment$F;
+
+  factory CopyWith$Fragment$F.stub(TRes res) = _CopyWithStubImpl$Fragment$F;
+
+  TRes call({String? name, String? $__typename});
+}
+
+class _CopyWithImpl$Fragment$F<TRes> implements CopyWith$Fragment$F<TRes> {
+  _CopyWithImpl$Fragment$F(this._instance, this._then);
+
+  final Fragment$F _instance;
+
+  final TRes Function(Fragment$F) _then;
+
+  static const _undefined = {};
+
+  TRes call({Object? name = _undefined, Object? $__typename = _undefined}) =>
+      _then(Fragment$F(
+          name: name == _undefined ? _instance.name : (name as String?),
+          $__typename: $__typename == _undefined || $__typename == null
+              ? _instance.$__typename
+              : ($__typename as String)));
+}
+
+class _CopyWithStubImpl$Fragment$F<TRes> implements CopyWith$Fragment$F<TRes> {
+  _CopyWithStubImpl$Fragment$F(this._res);
+
+  TRes _res;
+
+  call({String? name, String? $__typename}) => _res;
+}
+
+const fragmentDefinitionF = FragmentDefinitionNode(
+    name: NameNode(value: 'F'),
+    typeCondition: TypeConditionNode(
+        on: NamedTypeNode(name: NameNode(value: 'Query'), isNonNull: false)),
+    directives: [],
+    selectionSet: SelectionSetNode(selections: [
+      FieldNode(
+          name: NameNode(value: 'name'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null),
+      FieldNode(
+          name: NameNode(value: '__typename'),
+          alias: null,
+          arguments: [],
+          directives: [],
+          selectionSet: null)
+    ]));
+const documentNodeFragmentF = DocumentNode(definitions: [
+  fragmentDefinitionF,
+]);
+
+@JsonSerializable(explicitToJson: true)
+class Query$Q implements Fragment$F {
+  Query$Q({this.name, required this.$__typename});
+
+  @override
+  factory Query$Q.fromJson(Map<String, dynamic> json) =>
+      _$Query$QFromJson(json);
+
+  final String? name;
+
+  @JsonKey(name: '__typename')
+  final String $__typename;
+
+  Map<String, dynamic> toJson() => _$Query$QToJson(this);
+  int get hashCode {
+    final l$name = name;
+    final l$$__typename = $__typename;
+    return Object.hashAll([l$name, l$$__typename]);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (!(other is Query$Q) || runtimeType != other.runtimeType) return false;
+    final l$name = name;
+    final lOther$name = other.name;
+    if (l$name != lOther$name) return false;
+    final l$$__typename = $__typename;
+    final lOther$$__typename = other.$__typename;
+    if (l$$__typename != lOther$$__typename) return false;
+    return true;
+  }
+}
+
+extension UtilityExtension$Query$Q on Query$Q {
+  CopyWith$Query$Q<Query$Q> get copyWith => CopyWith$Query$Q(this, (i) => i);
+}
+
+abstract class CopyWith$Query$Q<TRes> {
+  factory CopyWith$Query$Q(Query$Q instance, TRes Function(Query$Q) then) =
+      _CopyWithImpl$Query$Q;
+
+  factory CopyWith$Query$Q.stub(TRes res) = _CopyWithStubImpl$Query$Q;
+
+  TRes call({String? name, String? $__typename});
+}
+
+class _CopyWithImpl$Query$Q<TRes> implements CopyWith$Query$Q<TRes> {
+  _CopyWithImpl$Query$Q(this._instance, this._then);
+
+  final Query$Q _instance;
+
+  final TRes Function(Query$Q) _then;
+
+  static const _undefined = {};
+
+  TRes call({Object? name = _undefined, Object? $__typename = _undefined}) =>
+      _then(Query$Q(
+          name: name == _undefined ? _instance.name : (name as String?),
+          $__typename: $__typename == _undefined || $__typename == null
+              ? _instance.$__typename
+              : ($__typename as String)));
+}
+
+class _CopyWithStubImpl$Query$Q<TRes> implements CopyWith$Query$Q<TRes> {
+  _CopyWithStubImpl$Query$Q(this._res);
+
+  TRes _res;
+
+  call({String? name, String? $__typename}) => _res;
+}
+
+const documentNodeQueryQ = DocumentNode(definitions: [
+  OperationDefinitionNode(
+      type: OperationType.query,
+      name: NameNode(value: 'Q'),
+      variableDefinitions: [],
+      directives: [],
+      selectionSet: SelectionSetNode(selections: [
+        FragmentSpreadNode(name: NameNode(value: 'F'), directives: []),
+        FieldNode(
+            name: NameNode(value: '__typename'),
+            alias: null,
+            arguments: [],
+            directives: [],
+            selectionSet: null)
+      ])),
+  fragmentDefinitionF,
+]);
+const possibleTypesMap = {};

--- a/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.g.dart
+++ b/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'document.graphql.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Fragment$F _$Fragment$FFromJson(Map<String, dynamic> json) => Fragment$F(
+      name: json['name'] as String?,
+      $__typename: json['__typename'] as String,
+    );
+
+Map<String, dynamic> _$Fragment$FToJson(Fragment$F instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      '__typename': instance.$__typename,
+    };
+
+Query$Q _$Query$QFromJson(Map<String, dynamic> json) => Query$Q(
+      name: json['name'] as String?,
+      $__typename: json['__typename'] as String,
+    );
+
+Map<String, dynamic> _$Query$QToJson(Query$Q instance) => <String, dynamic>{
+      'name': instance.name,
+      '__typename': instance.$__typename,
+    };


### PR DESCRIPTION
Currently, when an operation only contains a fragment it is not generated.