### PR TITLE
feat: Add client context

### DIFF
--- a/packages/graphql_switch/example/lib/main.dart
+++ b/packages/graphql_switch/example/lib/main.dart
@@ -7,12 +7,12 @@ import 'package:graphql_switch/graphql_switch.dart';
 import 'package:http/http.dart' as http;
 
 Future<Map<String, dynamic>> fetchGraphQL(
-  RequestParameters params,
+  RequestParameters<Map<String, String>> params,
   Map<String, dynamic> variables,
 ) async {
   final response = await http.post(
     Uri.parse('https://swapi-graphql.netlify.app/.netlify/functions/index'),
-    headers: {'content-type': 'application/json'},
+    headers: {'content-type': 'application/json', ...params.clientContext},
     body: json.encode({
       'query': params.text,
       'operationName': params.name,
@@ -25,6 +25,7 @@ Future<Map<String, dynamic>> fetchGraphQL(
 void main() async {
   final initializeResult = await SwitchClient.initialize(
     fetch: fetchGraphQL,
+    clientContext: <String, String>{},
   );
   runApp(
     SwitchClient(

--- a/packages/graphql_switch/example/lib/switch.dart
+++ b/packages/graphql_switch/example/lib/switch.dart
@@ -159,8 +159,11 @@ class SwitchClient extends InternalSwitchClient {
       Key? key})
       : super(child, initializeResult, key);
 
-  static Future<InitializeResult> initialize({required FetchFn fetch}) =>
-      InternalSwitchClient.initialize(_initialzer, fetch);
+  static Future<InitializeResult> initialize<TClientContext extends Object?>(
+          {required FetchFn<TClientContext> fetch,
+          required TClientContext clientContext}) =>
+      InternalSwitchClient.initialize<TClientContext>(
+          _initialzer, fetch, clientContext);
 }
 
 QueryResult<Query$FetchAllFilms> useQuery$FetchAllFilms(

--- a/packages/graphql_switch/lib/src/builder/print.dart
+++ b/packages/graphql_switch/lib/src/builder/print.dart
@@ -324,20 +324,36 @@ Iterable<Spec> _printHelpers(PrintContext<ContextRoot> pc) {
             (b) => b
               ..static = true
               ..name = 'initialize'
+              ..types = ListBuilder([refer('TClientContext extends Object?')])
               ..optionalParameters = ListBuilder([
                 Parameter(
                   (b) => b
                     ..name = 'fetch'
                     ..required = true
                     ..named = true
-                    ..type = refer('FetchFn'),
+                    ..type = TypeReference(
+                      (b) => b
+                        ..symbol = 'FetchFn'
+                        ..types = ListBuilder([refer('TClientContext')]),
+                    ),
+                ),
+                Parameter(
+                  (b) => b
+                    ..name = 'clientContext'
+                    ..required = true
+                    ..named = true
+                    ..type = refer('TClientContext'),
                 )
               ])
               ..returns = futureRefer(refer('InitializeResult'))
-              ..body =
-                  refer('InternalSwitchClient').property('initialize').call([
+              ..body = refer('InternalSwitchClient')
+                  .property('initialize')
+                  .call([
                 refer(kInitializerName),
                 refer('fetch'),
+                refer('clientContext')
+              ], {}, [
+                refer('TClientContext')
               ]).code,
           )
         ])

--- a/packages/graphql_switch/test/assets/initial_test/switch.dart
+++ b/packages/graphql_switch/test/assets/initial_test/switch.dart
@@ -137,8 +137,11 @@ class SwitchClient extends InternalSwitchClient {
       Key? key})
       : super(child, initializeResult, key);
 
-  static Future<InitializeResult> initialize({required FetchFn fetch}) =>
-      InternalSwitchClient.initialize(_initialzer, fetch);
+  static Future<InitializeResult> initialize<TClientContext extends Object?>(
+          {required FetchFn<TClientContext> fetch,
+          required TClientContext clientContext}) =>
+      InternalSwitchClient.initialize<TClientContext>(
+          _initialzer, fetch, clientContext);
 }
 
 QueryResult<Query$MyWidgetQuery> useQuery$MyWidgetQuery(

--- a/packages/graphql_switch/test/assets/initial_test/widget.dart
+++ b/packages/graphql_switch/test/assets/initial_test/widget.dart
@@ -1,14 +1,19 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:graphql_switch/graphql_switch.dart';
 import './switch.dart';
 
-Future<Map<String, dynamic>> fetch(params, variables) async {
+Future<Map<String, dynamic>> fetch(
+  RequestParameters<Object?> params,
+  variables,
+) async {
   return {};
 }
 
 void main() async {
   final result = await SwitchClient.initialize(
     fetch: fetch,
+    clientContext: null,
   );
 
   runApp(SwitchClient(


### PR DESCRIPTION
Add client context to RequestParameters. This is the only way to send custom data to the fetch method.