### PR TITLE
feat: allow parserFn to be overridden

### DIFF
--- a/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
+++ b/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
@@ -73,6 +73,10 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
                   'context',
                   'graphql.Context',
                 ),
+                printOptionsParameter(
+                  'parserFn',
+                  '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                ),
               ],
             )
             ..initializers = ListBuilder([
@@ -92,7 +96,7 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
                 'context': refer('context'),
                 'document': refer(c.namePrinter
                     .printDocumentDefinitionNodeName(context.path)),
-                'parserFn': printParserFnRef(c),
+                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
               }).code,
             ]),
         ),
@@ -144,6 +148,10 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
                   'context',
                   'graphql.Context',
                 ),
+                printOptionsParameter(
+                  'parserFn',
+                  '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                ),
               ],
             )
             ..initializers = ListBuilder([
@@ -162,7 +170,7 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
                 'context': refer('context'),
                 'document': refer(c.namePrinter
                     .printDocumentDefinitionNodeName(context.path)),
-                'parserFn': printParserFnRef(c),
+                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
               }).code,
             ]),
         ),
@@ -501,6 +509,10 @@ Spec printWatchOptions(
                   "bool",
                   defaultTo: literalFalse.code,
                 ),
+                printOptionsParameter(
+                  'parserFn',
+                  '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                ),
               ],
             )
             ..initializers = ListBuilder([
@@ -525,7 +537,7 @@ Spec printWatchOptions(
                   'carryForwardDataOnException',
                 ),
                 'fetchResults': refer('fetchResults'),
-                'parserFn': printParserFnRef(c),
+                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
               }).code,
             ]),
         ),

--- a/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
+++ b/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
@@ -76,6 +76,7 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
                 printOptionsParameter(
                   'parserFn',
                   '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                  defaultTo: printParserFnRef(c).code,
                 ),
               ],
             )
@@ -96,7 +97,7 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
                 'context': refer('context'),
                 'document': refer(c.namePrinter
                     .printDocumentDefinitionNodeName(context.path)),
-                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
+                'parserFn': refer('parserFn'),
               }).code,
             ]),
         ),
@@ -151,6 +152,7 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
                 printOptionsParameter(
                   'parserFn',
                   '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                  defaultTo: printParserFnRef(c).code,
                 ),
               ],
             )
@@ -170,7 +172,7 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
                 'context': refer('context'),
                 'document': refer(c.namePrinter
                     .printDocumentDefinitionNodeName(context.path)),
-                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
+                'parserFn': refer('parserFn'),
               }).code,
             ]),
         ),
@@ -409,6 +411,11 @@ Spec printMutationOptions(
                     'onError',
                     "graphql.OnError",
                   ),
+                  printOptionsParameter(
+                    'parserFn',
+                    '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                    defaultTo: printParserFnRef(c).code,
+                  ),
                 ],
               )
               ..initializers = ListBuilder([
@@ -436,7 +443,7 @@ Spec printMutationOptions(
                   'onError': refer('onError'),
                   'document': refer(c.namePrinter
                       .printDocumentDefinitionNodeName(context.path)),
-                  'parserFn': printParserFnRef(c),
+                  'parserFn': refer('parserFn'),
                 }).code,
               ]),
           ),
@@ -512,6 +519,7 @@ Spec printWatchOptions(
                 printOptionsParameter(
                   'parserFn',
                   '${c.namePrinter.printName(context.path)} Function(Map<String, dynamic>)',
+                  defaultTo: printParserFnRef(c).code,
                 ),
               ],
             )
@@ -537,7 +545,7 @@ Spec printWatchOptions(
                   'carryForwardDataOnException',
                 ),
                 'fetchResults': refer('fetchResults'),
-                'parserFn': refer('parserFn').ifNullThen(printParserFnRef(c)),
+                'parserFn': refer('parserFn'),
               }).code,
             ]),
         ),

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -900,7 +900,7 @@ class Options$Query$FetchSOptional
     Object? optimisticResult,
     Duration? pollInterval,
     graphql.Context? context,
-    _ParserFn<Query$FetchSOptional> parserFn,
+    _ParserFn<Query$FetchSOptional> parserFn = _parserFn$Query$FetchSOptional,
   }) : super(
           variables: variables?.toJson() ?? {},
           operationName: operationName,
@@ -911,7 +911,7 @@ class Options$Query$FetchSOptional
           pollInterval: pollInterval,
           context: context,
           document: documentNodeQueryFetchSOptional,
-          parserFn: parserFn ?? _parserFn$Query$FetchSOptional,
+          parserFn: parserFn,
         );
 }
 
@@ -1251,7 +1251,7 @@ class WatchOptions$Query$FetchSRequired
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
-    _ParserFn<Query$FetchSRequired> parserFn,
+    _ParserFn<Query$FetchSRequired> parserFn = _parserFn$Query$FetchSRequired,
   }) : super(
           variables: variables.toJson(),
           operationName: operationName,
@@ -1265,7 +1265,7 @@ class WatchOptions$Query$FetchSRequired
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: parserFn ?? _parserFn$Query$FetchSRequired,
+          parserFn: parserFn,
         );
 }
 
@@ -1469,7 +1469,8 @@ class WatchOptions$Query$FetchSNoVariables
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
-    _ParserFn<Query$FetchSNoVariables> parserFn,
+    _ParserFn<Query$FetchSNoVariables> parserFn =
+        _parserFn$Query$FetchSNoVariables,
   }) : super(
           operationName: operationName,
           fetchPolicy: fetchPolicy,
@@ -1482,7 +1483,7 @@ class WatchOptions$Query$FetchSNoVariables
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: parserFn ?? _parserFn$Query$FetchSNoVariables,
+          parserFn: parserFn,
         );
 }
 
@@ -1771,7 +1772,8 @@ class Options$Mutation$UpdateSOptional
     OnMutationCompleted$Mutation$UpdateSOptional? onCompleted,
     graphql.OnMutationUpdate<Mutation$UpdateSOptional>? update,
     graphql.OnError? onError,
-    _ParserFn<Mutation$UpdateSOptional> parserFn,
+    _ParserFn<Mutation$UpdateSOptional> parserFn =
+        _parserFn$Mutation$UpdateSOptional,
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables?.toJson() ?? {},
@@ -1792,7 +1794,7 @@ class Options$Mutation$UpdateSOptional
           update: update,
           onError: onError,
           document: documentNodeMutationUpdateSOptional,
-          parserFn: parserFn ?? _parserFn$Mutation$UpdateSOptional,
+          parserFn: parserFn,
         );
 
   final OnMutationCompleted$Mutation$UpdateSOptional? onCompletedWithParsed;
@@ -2135,7 +2137,8 @@ class WatchOptions$Mutation$UpdateSRequired
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
-    _ParserFn<Mutation$UpdateSRequired> parserFn,
+    _ParserFn<Mutation$UpdateSRequired> parserFn =
+        _parserFn$Mutation$UpdateSRequired,
   }) : super(
           variables: variables.toJson(),
           operationName: operationName,
@@ -2149,7 +2152,7 @@ class WatchOptions$Mutation$UpdateSRequired
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: parserFn ?? _parserFn$Mutation$UpdateSRequired,
+          parserFn: parserFn,
         );
 }
 
@@ -2297,7 +2300,8 @@ class Options$Mutation$UpdateSNoVariables
     OnMutationCompleted$Mutation$UpdateSNoVariables? onCompleted,
     graphql.OnMutationUpdate<Mutation$UpdateSNoVariables>? update,
     graphql.OnError? onError,
-    _ParserFn<Mutation$UpdateSNoVariables> parserFn,
+    _ParserFn<Mutation$UpdateSNoVariables> parserFn =
+        _parserFn$Mutation$UpdateSNoVariables,
   })  : onCompletedWithParsed = onCompleted,
         super(
           operationName: operationName,
@@ -2317,7 +2321,7 @@ class Options$Mutation$UpdateSNoVariables
           update: update,
           onError: onError,
           document: documentNodeMutationUpdateSNoVariables,
-          parserFn: parserFn ?? _parserFn$Mutation$UpdateSNoVariables,
+          parserFn: parserFn,
         );
 
   final OnMutationCompleted$Mutation$UpdateSNoVariables? onCompletedWithParsed;

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -886,6 +886,9 @@ Query$FetchSOptional _parserFn$Query$FetchSOptional(
         Map<String, dynamic> data) =>
     Query$FetchSOptional.fromJson(data);
 
+typedef _ParserFn<TParsed extends Object?> = TParsed Function(
+    Map<String, dynamic>)?;
+
 class Options$Query$FetchSOptional
     extends graphql.QueryOptions<Query$FetchSOptional> {
   Options$Query$FetchSOptional({
@@ -897,6 +900,7 @@ class Options$Query$FetchSOptional
     Object? optimisticResult,
     Duration? pollInterval,
     graphql.Context? context,
+    _ParserFn<Query$FetchSOptional> parserFn,
   }) : super(
           variables: variables?.toJson() ?? {},
           operationName: operationName,
@@ -907,7 +911,7 @@ class Options$Query$FetchSOptional
           pollInterval: pollInterval,
           context: context,
           document: documentNodeQueryFetchSOptional,
-          parserFn: _parserFn$Query$FetchSOptional,
+          parserFn: parserFn ?? _parserFn$Query$FetchSOptional,
         );
 }
 
@@ -925,6 +929,7 @@ class WatchOptions$Query$FetchSOptional
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Query$FetchSOptional> parserFn,
   }) : super(
           variables: variables?.toJson() ?? {},
           operationName: operationName,
@@ -938,7 +943,7 @@ class WatchOptions$Query$FetchSOptional
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Query$FetchSOptional,
+          parserFn: parserFn ?? _parserFn$Query$FetchSOptional,
         );
 }
 
@@ -1217,6 +1222,7 @@ class Options$Query$FetchSRequired
     Object? optimisticResult,
     Duration? pollInterval,
     graphql.Context? context,
+    _ParserFn<Query$FetchSRequired> parserFn,
   }) : super(
           variables: variables.toJson(),
           operationName: operationName,
@@ -1227,7 +1233,7 @@ class Options$Query$FetchSRequired
           pollInterval: pollInterval,
           context: context,
           document: documentNodeQueryFetchSRequired,
-          parserFn: _parserFn$Query$FetchSRequired,
+          parserFn: parserFn ?? _parserFn$Query$FetchSRequired,
         );
 }
 
@@ -1245,6 +1251,7 @@ class WatchOptions$Query$FetchSRequired
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Query$FetchSRequired> parserFn,
   }) : super(
           variables: variables.toJson(),
           operationName: operationName,
@@ -1258,7 +1265,7 @@ class WatchOptions$Query$FetchSRequired
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Query$FetchSRequired,
+          parserFn: parserFn ?? _parserFn$Query$FetchSRequired,
         );
 }
 
@@ -1435,6 +1442,7 @@ class Options$Query$FetchSNoVariables
     Object? optimisticResult,
     Duration? pollInterval,
     graphql.Context? context,
+    _ParserFn<Query$FetchSNoVariables> parserFn,
   }) : super(
           operationName: operationName,
           fetchPolicy: fetchPolicy,
@@ -1444,7 +1452,7 @@ class Options$Query$FetchSNoVariables
           pollInterval: pollInterval,
           context: context,
           document: documentNodeQueryFetchSNoVariables,
-          parserFn: _parserFn$Query$FetchSNoVariables,
+          parserFn: parserFn ?? _parserFn$Query$FetchSNoVariables,
         );
 }
 
@@ -1461,6 +1469,7 @@ class WatchOptions$Query$FetchSNoVariables
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Query$FetchSNoVariables> parserFn,
   }) : super(
           operationName: operationName,
           fetchPolicy: fetchPolicy,
@@ -1473,7 +1482,7 @@ class WatchOptions$Query$FetchSNoVariables
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Query$FetchSNoVariables,
+          parserFn: parserFn ?? _parserFn$Query$FetchSNoVariables,
         );
 }
 
@@ -1762,6 +1771,7 @@ class Options$Mutation$UpdateSOptional
     OnMutationCompleted$Mutation$UpdateSOptional? onCompleted,
     graphql.OnMutationUpdate<Mutation$UpdateSOptional>? update,
     graphql.OnError? onError,
+    _ParserFn<Mutation$UpdateSOptional> parserFn,
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables?.toJson() ?? {},
@@ -1782,7 +1792,7 @@ class Options$Mutation$UpdateSOptional
           update: update,
           onError: onError,
           document: documentNodeMutationUpdateSOptional,
-          parserFn: _parserFn$Mutation$UpdateSOptional,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSOptional,
         );
 
   final OnMutationCompleted$Mutation$UpdateSOptional? onCompletedWithParsed;
@@ -1810,6 +1820,7 @@ class WatchOptions$Mutation$UpdateSOptional
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Mutation$UpdateSOptional> parserFn,
   }) : super(
           variables: variables?.toJson() ?? {},
           operationName: operationName,
@@ -1823,7 +1834,7 @@ class WatchOptions$Mutation$UpdateSOptional
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Mutation$UpdateSOptional,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSOptional,
         );
 }
 
@@ -2075,6 +2086,7 @@ class Options$Mutation$UpdateSRequired
     OnMutationCompleted$Mutation$UpdateSRequired? onCompleted,
     graphql.OnMutationUpdate<Mutation$UpdateSRequired>? update,
     graphql.OnError? onError,
+    _ParserFn<Mutation$UpdateSRequired> parserFn,
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables.toJson(),
@@ -2095,7 +2107,7 @@ class Options$Mutation$UpdateSRequired
           update: update,
           onError: onError,
           document: documentNodeMutationUpdateSRequired,
-          parserFn: _parserFn$Mutation$UpdateSRequired,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSRequired,
         );
 
   final OnMutationCompleted$Mutation$UpdateSRequired? onCompletedWithParsed;
@@ -2123,6 +2135,7 @@ class WatchOptions$Mutation$UpdateSRequired
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Mutation$UpdateSRequired> parserFn,
   }) : super(
           variables: variables.toJson(),
           operationName: operationName,
@@ -2136,7 +2149,7 @@ class WatchOptions$Mutation$UpdateSRequired
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Mutation$UpdateSRequired,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSRequired,
         );
 }
 
@@ -2284,6 +2297,7 @@ class Options$Mutation$UpdateSNoVariables
     OnMutationCompleted$Mutation$UpdateSNoVariables? onCompleted,
     graphql.OnMutationUpdate<Mutation$UpdateSNoVariables>? update,
     graphql.OnError? onError,
+    _ParserFn<Mutation$UpdateSNoVariables> parserFn,
   })  : onCompletedWithParsed = onCompleted,
         super(
           operationName: operationName,
@@ -2303,7 +2317,7 @@ class Options$Mutation$UpdateSNoVariables
           update: update,
           onError: onError,
           document: documentNodeMutationUpdateSNoVariables,
-          parserFn: _parserFn$Mutation$UpdateSNoVariables,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSNoVariables,
         );
 
   final OnMutationCompleted$Mutation$UpdateSNoVariables? onCompletedWithParsed;
@@ -2330,6 +2344,7 @@ class WatchOptions$Mutation$UpdateSNoVariables
     bool? eagerlyFetchResults,
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
+    _ParserFn<Mutation$UpdateSNoVariables> parserFn,
   }) : super(
           operationName: operationName,
           fetchPolicy: fetchPolicy,
@@ -2342,7 +2357,7 @@ class WatchOptions$Mutation$UpdateSNoVariables
           eagerlyFetchResults: eagerlyFetchResults,
           carryForwardDataOnException: carryForwardDataOnException,
           fetchResults: fetchResults,
-          parserFn: _parserFn$Mutation$UpdateSNoVariables,
+          parserFn: parserFn ?? _parserFn$Mutation$UpdateSNoVariables,
         );
 }
 


### PR DESCRIPTION
This PR allows the `parserFn` function to be overridden.

We have the following use case: some of our GraphQL calls are quite heavy and cause slowdown on the UI thread when parsing the JSON. A simple fix to this is to parse this JSON in an isolate. Currently this isn't convenient using this library. We have to copy the generated query classes and explicitly remove the line that sets the `parserFn` function. We then manually call the exact same parsing functionality from our isolate, which solves the slowdown. This PR solves this issue, without breaking current functionality.

I did not add tests to this PR. Happy to add them, but will need a few pointers on the test architecture in this repo.

Example
=====

Before:

```dart
  final result = await client.query(_MyQuery(
        [...]
      ));
  // This does an implicit JSON parse that is too heavy for us!

  return Something.fromGraphQl(result.parsedData);
```

after:

```dart
  final json = await client.query(_MyQuery(
        [...],
        parserFn: null,
      ));

  return await compute(json)
```