### PR TITLE
Show more opinionated file location nested in lib

### DIFF
--- a/packages/graphql_codegen/README.md
+++ b/packages/graphql_codegen/README.md
@@ -43,7 +43,7 @@ For instance:
 Given schema
 
 ```graphql
-# schema.graphql
+# ./lib/schema.graphql
 
 type Query {
   fetch_person(id: ID!): Person
@@ -67,7 +67,7 @@ scalar URL
 and a query
 
 ```graphql
-# person.graphql
+# ./lib/person.graphql
 
 query FetchPerson($id: ID!) {
   fetch_person(id: $id) {


### PR DESCRIPTION
Users who place their `schema.graphql` file at the project root, but whose `person.graphql` files exist in the **lib** folder [may experience this error](https://github.com/heftapp/graphql_codegen/issues/80): `Invalid GraphQL: Failed to find operation type for OperationType.query` when running the builder. This error message does not sufficiently indicate the underlying problem of where the files are located.

By showing both the `schema.graphql` and `person.graphql` location in the code comment, it will better communicate to the user where to place both files. This seems to be the best opinionated file placement because most project structures will likely house their graphql files inside the **lib** folder. Therefore, it is important to show that the schema file should also be nested therein.