### PR TITLE
Improve Error Message

### DIFF
--- a/packages/graphql_codegen/lib/src/printer/base/property.dart
+++ b/packages/graphql_codegen/lib/src/printer/base/property.dart
@@ -107,7 +107,7 @@ TypeReference _printNamedTypeNode(
       (b) => b..symbol = context.namePrinter.printClassName(replacementContext),
     );
   } else {
-    throw StateError("Failed to generate type.");
+    throw StateError("Failed to generate type for ${typeNode.name.value}.");
   }
   if (typeNode.isNonNull) {
     return reference;


### PR DESCRIPTION
By including the name of the specific field that caused the error, this message can provide more helpful information to developers and users trying to troubleshoot the issue.