### PR TITLE
fix: Order builder before json_serializable

### DIFF
--- a/packages/graphql_codegen/build.yaml
+++ b/packages/graphql_codegen/build.yaml
@@ -5,3 +5,5 @@ builders:
     build_extensions: {'$lib$': ['.graphql.dart']}
     auto_apply: dependents
     build_to: source
+    runs_before:
+      - json_serializable:json_serializable


### PR DESCRIPTION
Fixes #297 (both portions actually!)

Apparently by default grapqhl_codegen runs *after* json_serializable causing types to not exist when json_serializable attempts to make sense of them. By having build_runner run this builder before json_serializable, this problem is avoided.

*Force-pushes to make verify_commits happy*