### PR TITLE
Proposal: Make `WatchQueryOptions`'s `variable` field optional

### DIFF
--- a/packages/graphql_codegen/example/lib/main.graphql.dart
+++ b/packages/graphql_codegen/example/lib/main.graphql.dart
@@ -388,7 +388,7 @@ class WatchOptions$Query$FetchPerson
     extends graphql.WatchQueryOptions<Query$FetchPerson> {
   WatchOptions$Query$FetchPerson({
     String? operationName,
-    required Variables$Query$FetchPerson variables,
+    Variables$Query$FetchPerson? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -400,7 +400,7 @@ class WatchOptions$Query$FetchPerson
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -466,8 +466,8 @@ graphql_flutter.QueryHookResult<Query$FetchPerson> useQuery$FetchPerson(
         Options$Query$FetchPerson options) =>
     graphql_flutter.useQuery(options);
 graphql.ObservableQuery<Query$FetchPerson> useWatchQuery$FetchPerson(
-        WatchOptions$Query$FetchPerson options) =>
-    graphql_flutter.useWatchQuery(options);
+        [WatchOptions$Query$FetchPerson? options]) =>
+    graphql_flutter.useWatchQuery(options ?? WatchOptions$Query$FetchPerson());
 
 class Query$FetchPerson$Widget
     extends graphql_flutter.Query<Query$FetchPerson> {
@@ -1566,7 +1566,7 @@ class WatchOptions$Mutation$UpdatePerson
     extends graphql.WatchQueryOptions<Mutation$UpdatePerson> {
   WatchOptions$Mutation$UpdatePerson({
     String? operationName,
-    required Variables$Mutation$UpdatePerson variables,
+    Variables$Mutation$UpdatePerson? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -1578,7 +1578,7 @@ class WatchOptions$Mutation$UpdatePerson
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,

--- a/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
+++ b/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
@@ -594,7 +594,6 @@ Spec printWatchOptions(
                   printOptionsParameter(
                     'variables',
                     c.namePrinter.printVariableClassName(context.path),
-                    isRequired: context.isVariablesRequired,
                   ),
                 printOptionsParameter(
                   'fetchPolicy',
@@ -642,9 +641,7 @@ Spec printWatchOptions(
             )
             ..initializers = ListBuilder([
               refer('super').call([], {
-                if (hasVariables && context.isVariablesRequired)
-                  'variables': refer('variables').property('toJson').call([])
-                else if (hasVariables)
+                if (hasVariables)
                   'variables': refer('variables')
                       .nullSafeProperty('toJson')
                       .call([]).ifNullThen(literalMap({})),

--- a/packages/graphql_codegen/lib/src/printer/clients/graphql_flutter.dart
+++ b/packages/graphql_codegen/lib/src/printer/clients/graphql_flutter.dart
@@ -365,24 +365,20 @@ Spec printMutationHook(PrintContext context) {
 }
 
 Spec printWatchHook(PrintContext context, String libraryHookName) {
-  final isOptionsRequried = context.context.isVariablesRequired;
   final parameter = Parameter(
     (b) => b
       ..type = TypeReference(
         (b) => b
           ..symbol = context.namePrinter
               .printGraphQLClientWatchOptionsName(context.path)
-          ..isNullable = !isOptionsRequried,
+          ..isNullable = true,
       )
       ..name = 'options',
   );
   return Method(
     (b) => b
-      ..requiredParameters = ListBuilder([
-        if (isOptionsRequried) parameter,
-      ])
       ..optionalParameters = ListBuilder([
-        if (!isOptionsRequried) parameter,
+        parameter,
       ])
       ..returns = TypeReference(
         (b) => b
@@ -393,11 +389,9 @@ Spec printWatchHook(PrintContext context, String libraryHookName) {
       ..name = context.namePrinter
           .printGraphQLFlutterClientWatchHookName(context.path)
       ..body = refer('graphql_flutter').property(libraryHookName).call([
-        isOptionsRequried
-            ? refer('options')
-            : refer('options').ifNullThen(refer(context.namePrinter
-                    .printGraphQLClientWatchOptionsName(context.path))
-                .newInstance([]))
+        refer('options').ifNullThen(refer(context.namePrinter
+                .printGraphQLClientWatchOptionsName(context.path))
+            .newInstance([]))
       ]).code,
   );
 }

--- a/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
@@ -802,7 +802,7 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
 class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
   WatchOptions$Query$Q({
     String? operationName,
-    required Variables$Query$Q variables,
+    Variables$Query$Q? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -814,7 +814,7 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -1475,7 +1475,7 @@ class WatchOptions$Query$FetchSRequired
     extends graphql.WatchQueryOptions<Query$FetchSRequired> {
   WatchOptions$Query$FetchSRequired({
     String? operationName,
-    required Variables$Query$FetchSRequired variables,
+    Variables$Query$FetchSRequired? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -1487,7 +1487,7 @@ class WatchOptions$Query$FetchSRequired
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -2389,7 +2389,7 @@ class WatchOptions$Mutation$UpdateSRequired
     extends graphql.WatchQueryOptions<Mutation$UpdateSRequired> {
   WatchOptions$Mutation$UpdateSRequired({
     String? operationName,
-    required Variables$Mutation$UpdateSRequired variables,
+    Variables$Mutation$UpdateSRequired? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -2401,7 +2401,7 @@ class WatchOptions$Mutation$UpdateSRequired
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -464,7 +464,7 @@ class WatchOptions$Mutation$UpdateSRequired
     extends graphql.WatchQueryOptions<Mutation$UpdateSRequired> {
   WatchOptions$Mutation$UpdateSRequired({
     String? operationName,
-    required Variables$Mutation$UpdateSRequired variables,
+    Variables$Mutation$UpdateSRequired? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -476,7 +476,7 @@ class WatchOptions$Mutation$UpdateSRequired
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -529,8 +529,9 @@ Mutation$UpdateSRequired$HookResult useMutation$UpdateSRequired(
 
 graphql.ObservableQuery<Mutation$UpdateSRequired>
     useWatchMutation$UpdateSRequired(
-            WatchOptions$Mutation$UpdateSRequired options) =>
-        graphql_flutter.useWatchMutation(options);
+            [WatchOptions$Mutation$UpdateSRequired? options]) =>
+        graphql_flutter.useWatchMutation(
+            options ?? WatchOptions$Mutation$UpdateSRequired());
 
 class WidgetOptions$Mutation$UpdateSRequired
     extends graphql.MutationOptions<Mutation$UpdateSRequired> {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -458,7 +458,7 @@ class WatchOptions$Query$FetchSRequired
     extends graphql.WatchQueryOptions<Query$FetchSRequired> {
   WatchOptions$Query$FetchSRequired({
     String? operationName,
-    required Variables$Query$FetchSRequired variables,
+    Variables$Query$FetchSRequired? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -470,7 +470,7 @@ class WatchOptions$Query$FetchSRequired
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -537,8 +537,9 @@ graphql_flutter.QueryHookResult<Query$FetchSRequired> useQuery$FetchSRequired(
         Options$Query$FetchSRequired options) =>
     graphql_flutter.useQuery(options);
 graphql.ObservableQuery<Query$FetchSRequired> useWatchQuery$FetchSRequired(
-        WatchOptions$Query$FetchSRequired options) =>
-    graphql_flutter.useWatchQuery(options);
+        [WatchOptions$Query$FetchSRequired? options]) =>
+    graphql_flutter
+        .useWatchQuery(options ?? WatchOptions$Query$FetchSRequired());
 
 class Query$FetchSRequired$Widget
     extends graphql_flutter.Query<Query$FetchSRequired> {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -908,7 +908,7 @@ class WatchOptions$Subscription$RequiredArg
     extends graphql.WatchQueryOptions<Subscription$RequiredArg> {
   WatchOptions$Subscription$RequiredArg({
     String? operationName,
-    required Variables$Subscription$RequiredArg variables,
+    Variables$Subscription$RequiredArg? variables,
     graphql.FetchPolicy? fetchPolicy,
     graphql.ErrorPolicy? errorPolicy,
     graphql.CacheRereadPolicy? cacheRereadPolicy,
@@ -920,7 +920,7 @@ class WatchOptions$Subscription$RequiredArg
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          variables: variables.toJson(),
+          variables: variables?.toJson() ?? {},
           operationName: operationName,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,


### PR DESCRIPTION
Thank you for creating this amazing tool and publishing it, we've been loving it!

As titled, this PR is a proposal to make `variable` field optional.
It makes sense to make it required for `query`, but since `watch` can

This is especially useful when using with hooks (ex: `useWatchQuery`).


