### PR TITLE
prints independent operation name

### DIFF
--- a/packages/graphql_codegen/lib/src/printer/base/operation.dart
+++ b/packages/graphql_codegen/lib/src/printer/base/operation.dart
@@ -21,6 +21,14 @@ List<Spec> printOperationSpecs(PrintContext<ContextOperation> elementContext) {
         elementContext,
         operation,
       ),
+    if (operation?.name != null)
+      Field(
+        (b) => b
+          ..modifier = FieldModifier.constant
+          ..name = elementContext.namePrinter
+              .printOperationNameConstantName(elementContext.context.path)
+          ..assignment = literalString(operation!.name!.value).code,
+      ),
     if (clients.contains(GraphQLCodegenConfigClient.graphql) ||
         clients.contains(GraphQLCodegenConfigClient.graphqlFlutter))
       ...printGraphQLClientSpecs(elementContext),

--- a/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
+++ b/packages/graphql_codegen/lib/src/printer/clients/graphql.dart
@@ -68,7 +68,6 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
             )
             ..modifier = FieldModifier.final$,
         ),
-        _printOperationNameDefinitionField(c),
       ])
       ..methods = ListBuilder([
         Method(
@@ -175,7 +174,12 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
                   'variables': refer('variables')
                       .nullSafeProperty('toJson')
                       .call([]).ifNullThen(literalMap({})),
-                'operationName': _printOperationName(c),
+                'operationName': refer('operationName').ifNullThen(
+                  refer(
+                    c.namePrinter
+                        .printOperationNameConstantName(c.context.path),
+                  ),
+                ),
                 'fetchPolicy': refer('fetchPolicy'),
                 'errorPolicy': refer('errorPolicy'),
                 'cacheRereadPolicy': refer('cacheRereadPolicy'),
@@ -200,28 +204,6 @@ Spec printQueryOptions(PrintContext<ContextOperation> c) {
   );
 }
 
-Expression _printOperationName(PrintContext<ContextOperation> c) {
-  return refer('operationName').ifNullThen(
-    CodeExpression(Code('operationNameDefinition')),
-  );
-}
-
-Field _printOperationNameDefinitionField(PrintContext<ContextOperation> c) {
-  final operationName = c.context.operation?.name?.value;
-
-  return Field(
-    (b) => b
-      ..static = true
-      ..modifier = FieldModifier.constant
-      ..type = Reference('String?')
-      ..name = 'operationNameDefinition'
-      ..assignment =
-          (!c.context.config.setOperationName || operationName == null)
-              ? null
-              : Code('"$operationName"'),
-  );
-}
-
 Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
   final context = c.context;
   return Class(
@@ -231,9 +213,7 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
         "graphql.SubscriptionOptions",
         refer(c.namePrinter.printClassName(context.path)),
       )
-      ..fields = ListBuilder([
-        _printOperationNameDefinitionField(c),
-      ])
+      ..fields = ListBuilder([])
       ..constructors = ListBuilder([
         Constructor(
           (b) => b
@@ -283,7 +263,12 @@ Spec printSubscriptionOptions(PrintContext<ContextOperation> c) {
                   'variables': refer('variables')
                       .nullSafeProperty('toJson')
                       .call([]).ifNullThen(literalMap({})),
-                'operationName': _printOperationName(c),
+                'operationName': refer('operationName').ifNullThen(
+                  refer(
+                    c.namePrinter
+                        .printOperationNameConstantName(c.context.path),
+                  ),
+                ),
                 'fetchPolicy': refer('fetchPolicy'),
                 'errorPolicy': refer('errorPolicy'),
                 'cacheRereadPolicy': refer('cacheRereadPolicy'),
@@ -463,14 +448,6 @@ Spec printMutationOptions(
             )
             ..modifier = FieldModifier.final$,
         ),
-        Field(
-          (b) => b
-            ..static = true
-            ..modifier = FieldModifier.constant
-            ..type = Reference('String')
-            ..name = 'operationNameDefinition'
-            ..assignment = Code('"${c.context.operation?.name?.value}"'),
-        ),
       ])
       ..methods = ListBuilder([
         Method(
@@ -578,7 +555,12 @@ Spec printMutationOptions(
                     'variables': refer('variables')
                         .nullSafeProperty('toJson')
                         .call([]).ifNullThen(literalMap({})),
-                  'operationName': _printOperationName(c),
+                  'operationName': refer('operationName').ifNullThen(
+                    refer(
+                      c.namePrinter
+                          .printOperationNameConstantName(c.context.path),
+                    ),
+                  ),
                   'fetchPolicy': refer('fetchPolicy'),
                   'errorPolicy': refer('errorPolicy'),
                   'cacheRereadPolicy': refer('cacheRereadPolicy'),
@@ -618,9 +600,7 @@ Spec printWatchOptions(
       ..extend = TypeReference((b) => b
         ..symbol = "graphql.WatchQueryOptions"
         ..types = ListBuilder([refer(c.namePrinter.printClassName(c.path))]))
-      ..fields = ListBuilder([
-        _printOperationNameDefinitionField(c),
-      ])
+      ..fields = ListBuilder([])
       ..constructors = ListBuilder([
         Constructor(
           (b) => b
@@ -685,7 +665,12 @@ Spec printWatchOptions(
                   'variables': refer('variables')
                       .nullSafeProperty('toJson')
                       .call([]).ifNullThen(literalMap({})),
-                'operationName': _printOperationName(c),
+                'operationName': refer('operationName').ifNullThen(
+                  refer(
+                    c.namePrinter
+                        .printOperationNameConstantName(c.context.path),
+                  ),
+                ),
                 'fetchPolicy': refer('fetchPolicy'),
                 'errorPolicy': refer('errorPolicy'),
                 'cacheRereadPolicy': refer('cacheRereadPolicy'),

--- a/packages/graphql_codegen/lib/src/printer/utils.dart
+++ b/packages/graphql_codegen/lib/src/printer/utils.dart
@@ -129,6 +129,9 @@ class NamePrinter {
   String printOperationNameDefinition(Name name) =>
       "operationName${printName(name)}";
 
+  String printOperationNameConstantName(Name name) =>
+      "operationName${printName(name)}";
+
   String printGraphQLFlutterClientMutationHookResultName(Name name) =>
       "${printName(name)}${separator}HookResult";
 

--- a/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
@@ -792,6 +792,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionFReport,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$docsWithTypename {
   Query$Q$docsWithTypename({required this.$__typename});

--- a/packages/graphql_codegen/test/assets/condition_example/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/condition_example/query.graphql.dart
@@ -176,3 +176,4 @@ const documentNodeQueryFetchShouldRender = DocumentNode(definitions: [
   fragmentDefinitionCondition,
   fragmentDefinitionNonCompositeCondition,
 ]);
+const operationNameQuery$FetchShouldRender = 'FetchShouldRender';

--- a/packages/graphql_codegen/test/assets/copy_with/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/copy_with/document.graphql.dart
@@ -487,6 +487,7 @@ const documentNodeQueryFoobar = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Foobar = 'Foobar';
 
 class Query$Foobar$ts {
   Query$Foobar$ts({

--- a/packages/graphql_codegen/test/assets/custom_enums/document_2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/custom_enums/document_2.graphql.dart
@@ -147,3 +147,4 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';

--- a/packages/graphql_codegen/test/assets/deprecated/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/deprecated/document.graphql.dart
@@ -366,4 +366,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/disable_copy_with/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/disable_copy_with/document.graphql.dart
@@ -518,6 +518,7 @@ const documentNodeQueryFetchScalars = DocumentNode(definitions: [
   fragmentDefinitionFA,
   fragmentDefinitionFB,
 ]);
+const operationNameQuery$FetchScalars = 'FetchScalars';
 
 class Query$FetchScalars$data {
   Query$FetchScalars$data({required this.$__typename});

--- a/packages/graphql_codegen/test/assets/enums/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/enums/query.graphql.dart
@@ -156,3 +156,4 @@ const documentNodeQueryFoobar = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Foobar = 'Foobar';

--- a/packages/graphql_codegen/test/assets/extends/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/extends/document.graphql.dart
@@ -575,6 +575,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$i {
   Query$Q$i({
@@ -834,4 +835,5 @@ const documentNodeMutationM = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$M = 'M';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
+++ b/packages/graphql_codegen/test/assets/first_test/a.graphql.dart
@@ -123,3 +123,4 @@ const documentNodeQueryFetchName = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$FetchName = 'FetchName';

--- a/packages/graphql_codegen/test/assets/fragment_and_field/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_and_field/document.graphql.dart
@@ -507,6 +507,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionFPerson,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$person {
   Query$Q$person({

--- a/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_imports/document2.graphql.dart
@@ -229,6 +229,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   fragmentDefinitionF1,
   fragmentDefinitionF2,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$t implements Fragment$F1 {
   Query$Q$t({this.name});

--- a/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_override/document.graphql.dart
@@ -1000,4 +1000,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   fragmentDefinitionT1,
   fragmentDefinitionT2,
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
@@ -748,6 +748,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionNameNode,
 ]);
+const operationNameQuery$Q = 'Q';
 Query$Q _parserFn$Query$Q(Map<String, dynamic> data) => Query$Q.fromJson(data);
 typedef OnQueryComplete$Query$Q = FutureOr<void> Function(
   Map<String, dynamic>?,
@@ -770,7 +771,7 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
   })  : onCompleteWithParsed = onComplete,
         super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -815,7 +816,7 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
@@ -755,6 +755,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$t implements Fragment$F$$T {
   Query$Q$t({

--- a/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_inheritence/document.graphql.dart
@@ -2321,6 +2321,7 @@ const documentNodeQueryFetch = DocumentNode(definitions: [
   fragmentDefinitionF,
   fragmentDefinitionF2,
 ]);
+const operationNameQuery$Fetch = 'Fetch';
 const possibleTypesMap = <String, Set<String>>{
   'Type': {'T1'}
 };

--- a/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_nested_data/document.graphql.dart
@@ -782,4 +782,5 @@ const documentNodeQueryFetch = DocumentNode(definitions: [
   fragmentDefinitionF3,
   fragmentDefinitionF4,
 ]);
+const operationNameQuery$Fetch = 'Fetch';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/gql_extensions/document.gql.dart
+++ b/packages/graphql_codegen/test/assets/gql_extensions/document.gql.dart
@@ -328,4 +328,5 @@ const documentNodeQueryFetchCount = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchCount = 'FetchCount';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -1068,6 +1068,7 @@ const documentNodeQueryFetchSOptional = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSOptional = 'FetchSOptional';
 Query$FetchSOptional _parserFn$Query$FetchSOptional(
         Map<String, dynamic> data) =>
     Query$FetchSOptional.fromJson(data);
@@ -1093,7 +1094,7 @@ class Options$Query$FetchSOptional
   })  : onCompleteWithParsed = onComplete,
         super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1139,7 +1140,7 @@ class WatchOptions$Query$FetchSOptional
     bool fetchResults = false,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1416,6 +1417,7 @@ const documentNodeQueryFetchSRequired = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSRequired = 'FetchSRequired';
 Query$FetchSRequired _parserFn$Query$FetchSRequired(
         Map<String, dynamic> data) =>
     Query$FetchSRequired.fromJson(data);
@@ -1441,7 +1443,7 @@ class Options$Query$FetchSRequired
   })  : onCompleteWithParsed = onComplete,
         super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1487,7 +1489,7 @@ class WatchOptions$Query$FetchSRequired
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1660,6 +1662,7 @@ const documentNodeQueryFetchSNoVariables = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSNoVariables = 'FetchSNoVariables';
 Query$FetchSNoVariables _parserFn$Query$FetchSNoVariables(
         Map<String, dynamic> data) =>
     Query$FetchSNoVariables.fromJson(data);
@@ -1683,7 +1686,7 @@ class Options$Query$FetchSNoVariables
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1729,7 +1732,7 @@ class WatchOptions$Query$FetchSNoVariables
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2010,6 +2013,7 @@ const documentNodeMutationUpdateSOptional = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSOptional = 'UpdateSOptional';
 Mutation$UpdateSOptional _parserFn$Mutation$UpdateSOptional(
         Map<String, dynamic> data) =>
     Mutation$UpdateSOptional.fromJson(data);
@@ -2035,7 +2039,7 @@ class Options$Mutation$UpdateSOptional
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2083,7 +2087,7 @@ class WatchOptions$Mutation$UpdateSOptional
     bool fetchResults = false,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2327,6 +2331,7 @@ const documentNodeMutationUpdateSRequired = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSRequired = 'UpdateSRequired';
 Mutation$UpdateSRequired _parserFn$Mutation$UpdateSRequired(
         Map<String, dynamic> data) =>
     Mutation$UpdateSRequired.fromJson(data);
@@ -2352,7 +2357,7 @@ class Options$Mutation$UpdateSRequired
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2400,7 +2405,7 @@ class WatchOptions$Mutation$UpdateSRequired
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2538,6 +2543,7 @@ const documentNodeMutationUpdateSNoVariables = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSNoVariables = 'UpdateSNoVariables';
 Mutation$UpdateSNoVariables _parserFn$Mutation$UpdateSNoVariables(
         Map<String, dynamic> data) =>
     Mutation$UpdateSNoVariables.fromJson(data);
@@ -2562,7 +2568,8 @@ class Options$Mutation$UpdateSNoVariables
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName:
+              operationName ?? operationNameMutation$UpdateSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -2608,7 +2615,8 @@ class WatchOptions$Mutation$UpdateSNoVariables
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName:
+              operationName ?? operationNameMutation$UpdateSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_infer_graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_infer_graphql_client/document.graphql.dart
@@ -296,6 +296,7 @@ const documentNodeMutationUpdateSNo = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSNo = 'UpdateSNo';
 Mutation$UpdateSNo _parserFn$Mutation$UpdateSNo(Map<String, dynamic> data) =>
     Mutation$UpdateSNo.fromJson(data);
 typedef OnMutationCompleted$Mutation$UpdateSNo = FutureOr<void> Function(
@@ -318,7 +319,7 @@ class Options$Mutation$UpdateSNo
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -362,7 +363,7 @@ class WatchOptions$Mutation$UpdateSNo
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -430,7 +431,7 @@ class WidgetOptions$Mutation$UpdateSNo
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
@@ -296,6 +296,7 @@ const documentNodeMutationUpdateSNo = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSNo = 'UpdateSNo';
 Mutation$UpdateSNo _parserFn$Mutation$UpdateSNo(Map<String, dynamic> data) =>
     Mutation$UpdateSNo.fromJson(data);
 typedef OnMutationCompleted$Mutation$UpdateSNo = FutureOr<void> Function(
@@ -318,7 +319,7 @@ class Options$Mutation$UpdateSNo
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -362,7 +363,7 @@ class WatchOptions$Mutation$UpdateSNo
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -430,7 +431,7 @@ class WidgetOptions$Mutation$UpdateSNo
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSNo,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
@@ -411,6 +411,7 @@ const documentNodeMutationUpdateSOptional = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSOptional = 'UpdateSOptional';
 Mutation$UpdateSOptional _parserFn$Mutation$UpdateSOptional(
         Map<String, dynamic> data) =>
     Mutation$UpdateSOptional.fromJson(data);
@@ -436,7 +437,7 @@ class Options$Mutation$UpdateSOptional
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -484,7 +485,7 @@ class WatchOptions$Mutation$UpdateSOptional
     bool fetchResults = false,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -555,7 +556,7 @@ class WidgetOptions$Mutation$UpdateSOptional
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -404,6 +404,7 @@ const documentNodeMutationUpdateSRequired = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$UpdateSRequired = 'UpdateSRequired';
 Mutation$UpdateSRequired _parserFn$Mutation$UpdateSRequired(
         Map<String, dynamic> data) =>
     Mutation$UpdateSRequired.fromJson(data);
@@ -429,7 +430,7 @@ class Options$Mutation$UpdateSRequired
   })  : onCompletedWithParsed = onCompleted,
         super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -477,7 +478,7 @@ class WatchOptions$Mutation$UpdateSRequired
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -547,7 +548,7 @@ class WidgetOptions$Mutation$UpdateSRequired
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$UpdateSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -296,6 +296,7 @@ const documentNodeQueryFetchSNoVariables = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSNoVariables = 'FetchSNoVariables';
 Query$FetchSNoVariables _parserFn$Query$FetchSNoVariables(
         Map<String, dynamic> data) =>
     Query$FetchSNoVariables.fromJson(data);
@@ -319,7 +320,7 @@ class Options$Query$FetchSNoVariables
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -365,7 +366,7 @@ class WatchOptions$Query$FetchSNoVariables
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSNoVariables,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -407,6 +407,7 @@ const documentNodeQueryFetchSOptional = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSOptional = 'FetchSOptional';
 Query$FetchSOptional _parserFn$Query$FetchSOptional(
         Map<String, dynamic> data) =>
     Query$FetchSOptional.fromJson(data);
@@ -432,7 +433,7 @@ class Options$Query$FetchSOptional
   })  : onCompleteWithParsed = onComplete,
         super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -478,7 +479,7 @@ class WatchOptions$Query$FetchSOptional
     bool fetchResults = false,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSOptional,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -400,6 +400,7 @@ const documentNodeQueryFetchSRequired = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchSRequired = 'FetchSRequired';
 Query$FetchSRequired _parserFn$Query$FetchSRequired(
         Map<String, dynamic> data) =>
     Query$FetchSRequired.fromJson(data);
@@ -425,7 +426,7 @@ class Options$Query$FetchSRequired
   })  : onCompleteWithParsed = onComplete,
         super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -471,7 +472,7 @@ class WatchOptions$Query$FetchSRequired
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$FetchSRequired,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -362,6 +362,7 @@ const documentNodeSubscriptionNoArgs = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameSubscription$NoArgs = 'NoArgs';
 Subscription$NoArgs _parserFn$Subscription$NoArgs(Map<String, dynamic> data) =>
     Subscription$NoArgs.fromJson(data);
 
@@ -376,7 +377,7 @@ class Options$Subscription$NoArgs
     Subscription$NoArgs? typedOptimisticResult,
     graphql.Context? context,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$NoArgs,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -402,7 +403,7 @@ class WatchOptions$Subscription$NoArgs
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$NoArgs,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -876,6 +877,7 @@ const documentNodeSubscriptionRequiredArg = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameSubscription$RequiredArg = 'RequiredArg';
 Subscription$RequiredArg _parserFn$Subscription$RequiredArg(
         Map<String, dynamic> data) =>
     Subscription$RequiredArg.fromJson(data);
@@ -893,7 +895,7 @@ class Options$Subscription$RequiredArg
     graphql.Context? context,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$RequiredArg,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -921,7 +923,7 @@ class WatchOptions$Subscription$RequiredArg
     bool fetchResults = false,
   }) : super(
           variables: variables.toJson(),
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$RequiredArg,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1407,6 +1409,7 @@ const documentNodeSubscriptionOptionalArg = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameSubscription$OptionalArg = 'OptionalArg';
 Subscription$OptionalArg _parserFn$Subscription$OptionalArg(
         Map<String, dynamic> data) =>
     Subscription$OptionalArg.fromJson(data);
@@ -1424,7 +1427,7 @@ class Options$Subscription$OptionalArg
     graphql.Context? context,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$OptionalArg,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -1452,7 +1455,7 @@ class WatchOptions$Subscription$OptionalArg
     bool fetchResults = false,
   }) : super(
           variables: variables?.toJson() ?? {},
-          operationName: operationName,
+          operationName: operationName ?? operationNameSubscription$OptionalArg,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_naming_config/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_naming_config/document.graphql.dart
@@ -479,6 +479,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery___Q = 'Q';
 Query___Q _parserFn___Query___Q(Map<String, dynamic> data) =>
     Query___Q.fromJson(data);
 typedef OnQueryComplete___Query___Q = FutureOr<void> Function(
@@ -500,7 +501,7 @@ class Options___Query___Q extends graphql.QueryOptions<Query___Q> {
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery___Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -543,7 +544,7 @@ class WatchOptions___Query___Q extends graphql.WatchQueryOptions<Query___Q> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery___Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/include_if_null_input/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/include_if_null_input/document.graphql.dart
@@ -587,4 +587,5 @@ const documentNodeQueryQ1 = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q1 = 'Q1';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/include_skip/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/include_skip/document.graphql.dart
@@ -383,6 +383,7 @@ const documentNodeQueryQ1 = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q1 = 'Q1';
 
 class Query$Q1$foo {
   Query$Q1$foo({

--- a/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
@@ -455,6 +455,7 @@ const documentNodeQueryFetchImplementations = DocumentNode(definitions: [
   fragmentDefinitionFragmentA,
   fragmentDefinitionFragmentB,
 ]);
+const operationNameQuery$FetchImplementations = 'FetchImplementations';
 
 class Query$FetchImplementations$interface {
   Query$FetchImplementations$interface({

--- a/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
@@ -510,6 +510,7 @@ const documentNodeQueryFetchI = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchI = 'FetchI';
 
 class Query$FetchI$i1 {
   Query$FetchI$i1({

--- a/packages/graphql_codegen/test/assets/introspection_schema/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/introspection_schema/document.graphql.dart
@@ -1680,6 +1680,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Introspection {
   Query$Introspection({
@@ -2050,6 +2051,7 @@ const documentNodeQueryIntrospection = DocumentNode(definitions: [
   fragmentDefinitionInputValue,
   fragmentDefinitionTypeRef,
 ]);
+const operationNameQuery$Introspection = 'Introspection';
 
 class Query$Introspection$__schema {
   Query$Introspection$__schema({

--- a/packages/graphql_codegen/test/assets/issue_158/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_158/document.graphql.dart
@@ -667,6 +667,7 @@ const documentNodeQueryGetPerson = DocumentNode(definitions: [
   ),
   fragmentDefinitionPersonSummary,
 ]);
+const operationNameQuery$GetPerson = 'GetPerson';
 
 class Query$GetPerson$person implements Fragment$PersonSummary$$Person {
   Query$GetPerson$person({

--- a/packages/graphql_codegen/test/assets/issue_168/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_168/schema.graphql.dart
@@ -706,6 +706,7 @@ const documentNodeQueryWalletGetContent = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$WalletGetContent = 'WalletGetContent';
 
 class Query$WalletGetContent$walletGetContent {
   Query$WalletGetContent$walletGetContent({

--- a/packages/graphql_codegen/test/assets/issue_191/mutation.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/mutation.graphql.dart
@@ -143,6 +143,7 @@ const documentNodeMutationM = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$M = 'M';
 Mutation$M _parserFn$Mutation$M(Map<String, dynamic> data) =>
     Mutation$M.fromJson(data);
 typedef OnMutationCompleted$Mutation$M = FutureOr<void> Function(
@@ -164,7 +165,7 @@ class Options$Mutation$M extends graphql.MutationOptions<Mutation$M> {
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameMutation$M,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -183,8 +184,6 @@ class Options$Mutation$M extends graphql.MutationOptions<Mutation$M> {
         );
 
   final OnMutationCompleted$Mutation$M? onCompletedWithParsed;
-
-  static const String operationNameDefinition = "M";
 
   @override
   List<Object?> get properties => [
@@ -209,7 +208,7 @@ class WatchOptions$Mutation$M extends graphql.WatchQueryOptions<Mutation$M> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameMutation$M,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -222,8 +221,6 @@ class WatchOptions$Mutation$M extends graphql.WatchQueryOptions<Mutation$M> {
           fetchResults: fetchResults,
           parserFn: _parserFn$Mutation$M,
         );
-
-  static const String? operationNameDefinition = "M";
 }
 
 extension ClientExtension$Mutation$M on graphql.GraphQLClient {

--- a/packages/graphql_codegen/test/assets/issue_191/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/query.graphql.dart
@@ -143,6 +143,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 Query$Q _parserFn$Query$Q(Map<String, dynamic> data) => Query$Q.fromJson(data);
 typedef OnQueryComplete$Query$Q = FutureOr<void> Function(
   Map<String, dynamic>?,
@@ -163,7 +164,7 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -182,8 +183,6 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
         );
 
   final OnQueryComplete$Query$Q? onCompleteWithParsed;
-
-  static const String? operationNameDefinition = "Q";
 
   @override
   List<Object?> get properties => [
@@ -208,7 +207,7 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -221,8 +220,6 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
           fetchResults: fetchResults,
           parserFn: _parserFn$Query$Q,
         );
-
-  static const String? operationNameDefinition = "Q";
 }
 
 class FetchMoreOptions$Query$Q extends graphql.FetchMoreOptions {

--- a/packages/graphql_codegen/test/assets/issue_191/subscription.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/subscription.graphql.dart
@@ -147,6 +147,7 @@ const documentNodeSubscriptionS = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameSubscription$S = 'S';
 Subscription$S _parserFn$Subscription$S(Map<String, dynamic> data) =>
     Subscription$S.fromJson(data);
 
@@ -161,7 +162,7 @@ class Options$Subscription$S
     Subscription$S? typedOptimisticResult,
     graphql.Context? context,
   }) : super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameSubscription$S,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -170,8 +171,6 @@ class Options$Subscription$S
           document: documentNodeSubscriptionS,
           parserFn: _parserFn$Subscription$S,
         );
-
-  static const String? operationNameDefinition = "S";
 }
 
 class WatchOptions$Subscription$S
@@ -189,7 +188,7 @@ class WatchOptions$Subscription$S
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName ?? operationNameDefinition,
+          operationName: operationName ?? operationNameSubscription$S,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -202,8 +201,6 @@ class WatchOptions$Subscription$S
           fetchResults: fetchResults,
           parserFn: _parserFn$Subscription$S,
         );
-
-  static const String? operationNameDefinition = "S";
 }
 
 class FetchMoreOptions$Subscription$S extends graphql.FetchMoreOptions {

--- a/packages/graphql_codegen/test/assets/issue_192/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_192/document.graphql.dart
@@ -373,6 +373,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$book {
   Query$Q$book({

--- a/packages/graphql_codegen/test/assets/issue_206/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_206/document.graphql.dart
@@ -1192,6 +1192,7 @@ const documentNodeMutationBla = DocumentNode(definitions: [
   fragmentDefinitionEventFragment,
   fragmentDefinitionUserPublicFragment,
 ]);
+const operationNameMutation$Bla = 'Bla';
 
 class Mutation$Bla$bla {
   Mutation$Bla$bla({required this.$__typename});

--- a/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaA/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaA/document.graphql.dart
@@ -324,6 +324,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 Query$Q _parserFn$Query$Q(Map<String, dynamic> data) => Query$Q.fromJson(data);
 typedef OnQueryComplete$Query$Q = FutureOr<void> Function(
   Map<String, dynamic>?,
@@ -344,7 +345,7 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -387,7 +388,7 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaB/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaB/document.graphql.dart
@@ -324,6 +324,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 Query$Q _parserFn$Query$Q(Map<String, dynamic> data) => Query$Q.fromJson(data);
 typedef OnQueryComplete$Query$Q = FutureOr<void> Function(
   Map<String, dynamic>?,
@@ -344,7 +345,7 @@ class Options$Query$Q extends graphql.QueryOptions<Query$Q> {
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -387,7 +388,7 @@ class WatchOptions$Query$Q extends graphql.WatchQueryOptions<Query$Q> {
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Q,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/issue_239/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_239/document.graphql.dart
@@ -554,6 +554,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionHotelBooking,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$booking {
   Query$Q$booking({required this.$__typename});

--- a/packages/graphql_codegen/test/assets/issue_288/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_288/document.graphql.dart
@@ -1518,6 +1518,7 @@ const documentNodeQueryGetUser = DocumentNode(definitions: [
   fragmentDefinitionFullFriendRequestNotification,
   fragmentDefinitionFullNewsNotification,
 ]);
+const operationNameQuery$GetUser = 'GetUser';
 
 class Variables$Query$GetNotifications {
   factory Variables$Query$GetNotifications({required String username}) =>
@@ -1834,6 +1835,7 @@ const documentNodeQueryGetNotifications = DocumentNode(definitions: [
   fragmentDefinitionFullFriendRequestNotification,
   fragmentDefinitionFullNewsNotification,
 ]);
+const operationNameQuery$GetNotifications = 'GetNotifications';
 
 class Query$GetNotifications$getUser {
   Query$GetNotifications$getUser({

--- a/packages/graphql_codegen/test/assets/issue_293/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_293/document.graphql.dart
@@ -1607,4 +1607,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/issue_306/document.graphqls.dart
+++ b/packages/graphql_codegen/test/assets/issue_306/document.graphqls.dart
@@ -322,4 +322,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/issue_318/lib/query1/q.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_318/lib/query1/q.graphql.dart
@@ -145,3 +145,4 @@ const documentNodeQueryFetchHello = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchHello = 'FetchHello';

--- a/packages/graphql_codegen/test/assets/issue_318/lib/query2/q.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_318/lib/query2/q.graphql.dart
@@ -145,3 +145,4 @@ const documentNodeQueryFetchHello = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchHello = 'FetchHello';

--- a/packages/graphql_codegen/test/assets/issue_331/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_331/document.graphql.dart
@@ -367,6 +367,7 @@ const documentNodeQueryFooQuery = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FooQuery = 'FooQuery';
 
 class Query$FooQuery$foo {
   Query$FooQuery$foo({

--- a/packages/graphql_codegen/test/assets/issue_348/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_348/document.graphql.dart
@@ -286,4 +286,5 @@ const documentNodeQueryFetchScalars = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchScalars = 'FetchScalars';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/issue_370/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_370/document.graphql.dart
@@ -1116,6 +1116,7 @@ const documentNodeQueryMediaMinimal = DocumentNode(definitions: [
   ),
   fragmentDefinitionMediaMinimalFrag,
 ]);
+const operationNameQuery$MediaMinimal = 'MediaMinimal';
 
 class Variables$Query$MediaFull {
   factory Variables$Query$MediaFull({
@@ -1466,6 +1467,7 @@ const documentNodeQueryMediaFull = DocumentNode(definitions: [
   ),
   fragmentDefinitionMediaMinimalFrag,
 ]);
+const operationNameQuery$MediaFull = 'MediaFull';
 
 class Query$MediaFull$Media implements Fragment$MediaMinimalFrag {
   Query$MediaFull$Media({

--- a/packages/graphql_codegen/test/assets/json_converters/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/json_converters/document.graphql.dart
@@ -450,4 +450,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
@@ -891,6 +891,7 @@ const documentNodeQueryFetchStuff = DocumentNode(definitions: [
   fragmentDefinitionFragmentA,
   fragmentDefinitionFragmentI,
 ]);
+const operationNameQuery$FetchStuff = 'FetchStuff';
 
 class Query$FetchStuff$field {
   Query$FetchStuff$field({

--- a/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
@@ -982,6 +982,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   fragmentDefinitionF2,
   fragmentDefinitionF3,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$field implements Fragment$F0 {
   Query$Q$field({

--- a/packages/graphql_codegen/test/assets/naming_config/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/naming_config/document.graphql.dart
@@ -371,4 +371,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery___Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/nested_inline_and_fragment_spread/document.graphql.dart
@@ -651,6 +651,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$t implements Fragment$F {
   Query$Q$t({this.t});
@@ -1216,6 +1217,7 @@ const documentNodeQueryQ2 = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q2 = 'Q2';
 
 class Query$Q2$t implements Fragment$F {
   Query$Q2$t({this.t});

--- a/packages/graphql_codegen/test/assets/operation_name_collision/mutation.graphql.dart
+++ b/packages/graphql_codegen/test/assets/operation_name_collision/mutation.graphql.dart
@@ -141,6 +141,7 @@ const documentNodeMutationOperation = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameMutation$Operation = 'Operation';
 Mutation$Operation _parserFn$Mutation$Operation(Map<String, dynamic> data) =>
     Mutation$Operation.fromJson(data);
 typedef OnMutationCompleted$Mutation$Operation = FutureOr<void> Function(
@@ -163,7 +164,7 @@ class Options$Mutation$Operation
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$Operation,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -207,7 +208,7 @@ class WatchOptions$Mutation$Operation
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$Operation,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -275,7 +276,7 @@ class WidgetOptions$Mutation$Operation
     graphql.OnError? onError,
   })  : onCompletedWithParsed = onCompleted,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameMutation$Operation,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/operation_name_collision/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/operation_name_collision/query.graphql.dart
@@ -107,6 +107,7 @@ const documentNodeQueryOperation = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Operation = 'Operation';
 Query$Operation _parserFn$Query$Operation(Map<String, dynamic> data) =>
     Query$Operation.fromJson(data);
 typedef OnQueryComplete$Query$Operation = FutureOr<void> Function(
@@ -128,7 +129,7 @@ class Options$Query$Operation extends graphql.QueryOptions<Query$Operation> {
     graphql.OnQueryError? onError,
   })  : onCompleteWithParsed = onComplete,
         super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Operation,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,
@@ -172,7 +173,7 @@ class WatchOptions$Query$Operation
     bool carryForwardDataOnException = true,
     bool fetchResults = false,
   }) : super(
-          operationName: operationName,
+          operationName: operationName ?? operationNameQuery$Operation,
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
           cacheRereadPolicy: cacheRereadPolicy,

--- a/packages/graphql_codegen/test/assets/output_directory/__generated/folder/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/output_directory/__generated/folder/document.graphql.dart
@@ -322,4 +322,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/output_directory_2/f2/__generated__/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/output_directory_2/f2/__generated__/document.graphql.dart
@@ -142,3 +142,4 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';

--- a/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/query_with_single_fragment/document.graphql.dart
@@ -466,4 +466,5 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q = 'Q';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/root_relative_in_lib_output/lib/__generated__/queries/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/root_relative_in_lib_output/lib/__generated__/queries/document.graphql.dart
@@ -140,3 +140,4 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q = 'Q';

--- a/packages/graphql_codegen/test/assets/root_relative_output/lib/__generated__/queries/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/root_relative_output/lib/__generated__/queries/document.graphql.dart
@@ -140,3 +140,4 @@ const documentNodeQueryQ = DocumentNode(definitions: [
   ),
   fragmentDefinitionF,
 ]);
+const operationNameQuery$Q = 'Q';

--- a/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scalars/document.graphql.dart
@@ -464,4 +464,5 @@ const documentNodeQueryFetchScalars = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchScalars = 'FetchScalars';
 const possibleTypesMap = <String, Set<String>>{};

--- a/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/a.query.graphql.dart
@@ -185,6 +185,7 @@ const documentNodeQueryFetchPerson = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchPerson = 'FetchPerson';
 
 class Query$FetchPerson$fetchPerson {
   Query$FetchPerson$fetchPerson({

--- a/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/scopes/b.query.graphql.dart
@@ -192,6 +192,7 @@ const documentNodeQueryFetchPerson = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$FetchPerson = 'FetchPerson';
 
 class Query$FetchPerson$fetchPerson {
   Query$FetchPerson$fetchPerson({

--- a/packages/graphql_codegen/test/assets/unions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/unions/document.graphql.dart
@@ -335,6 +335,7 @@ const documentNodeQueryQ = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Q = 'Q';
 
 class Query$Q$u {
   Query$Q$u({required this.$__typename});

--- a/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
+++ b/packages/graphql_codegen/test/assets/variables/variables.graphql.dart
@@ -239,6 +239,7 @@ const documentNodeQueryHiBob = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$HiBob = 'HiBob';
 
 class Query$HiBob$field {
   Query$HiBob$field({required this.value});

--- a/packages/graphql_codegen/test/assets/when_extensions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/when_extensions/document.graphql.dart
@@ -398,6 +398,7 @@ const documentNodeQueryQuery = DocumentNode(definitions: [
     ]),
   ),
 ]);
+const operationNameQuery$Query = 'Query';
 
 class Query$Query$u {
   Query$Query$u({


### PR DESCRIPTION
Hi @budde377 

this PR adds printing of an independent operation name for the cases when we do not use `graphql` and `graphql_flutter` clients.

For example when we use https://github.com/artflutter/graphql_flutter_bloc and want to pass `operationName` to `WatchQueryOptions`
https://github.com/artflutter/graphql_flutter_bloc/blob/master/test/query_bloc_test.dart#L26

I see that there is a class `WatchOptions$Query` but it is being generated only in case if we add client generation.

