### PR TITLE
Upgrade build to `4.0.0`

### DIFF
--- a/packages/graphql_codegen/example/pubspec.lock
+++ b/packages/graphql_codegen/example/pubspec.lock
@@ -5,34 +5,34 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "89.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "974859dc0ff5f37bc4313244b3218c791810d03ab3470a579580279ba971a48d"
+      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.1"
+    version: "8.2.0"
   args:
     dependency: transitive
     description:
       name: args
-      sha256: bf9f5caeea8d8fe6721a9c358dd8a5c1947b27f1cfaa18b39c301273594919e6
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,50 +45,50 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: cef23f1eda9b57566c81e2133d196f8e3df48f244b317368d65c5943d91148f0
+      sha256: ce76b1d48875e3233fde17717c23d1f60a91cc631597e49a400c89b475395b1d
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "3.1.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "294a2edaf4814a378725bfe6358210196f5ea37af89ecd81bfa32960113d4948"
+      sha256: "8e928697a82be082206edb0b9c99c5a4ad6bc31c9e9b8b2f291ae65cd4a25daa"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.4"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "99d3980049739a985cf9b21f30881f46db3ebc62c5b8d5e60e27440876b1ba1e"
+      sha256: d1d57f7807debd7349b4726a19fd32ec8bc177c71ad0febf91a20f84cd2d4b46
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "3.0.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "74691599a5bc750dc96a6b4bfd48f7d9d66453eab04c7f4063134800d6a5c573"
+      sha256: b24597fceb695969d47025c958f3837f9f0122e237c6a22cb082a5ac66c3ca30
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.14"
+    version: "2.7.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "22e3aa1c80e0ada3722fe5b63fd43d9c8990759d0a2cf489c8c5d7b2bdebc021"
+      sha256: "066dda7f73d8eb48ba630a55acb50c4a84a2e6b453b1cb4567f581729e794f7b"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "9.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "28a712df2576b63c6c005c465989a348604960c0958d28be5303ba9baa841ac2"
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.9.3"
+    version: "8.12.0"
   characters:
     dependency: transitive
     description:
@@ -117,18 +117,26 @@ packages:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
+  cli_config:
+    dependency: transitive
+    description:
+      name: cli_config
+      sha256: ac20a183a07002b700f0c25e61b7ee46b23c309d76ab7b7640a028f18e4d99ec
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -141,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "8a68739d3ee113e51ad35583fdf9ab82c55d09d693d3c39da1aebab87c938412"
+      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.5"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -165,10 +173,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: e3493833ea012784c740e341952298f1cc77f1f01b1bbc3eb4eecf6984fb7f43
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -181,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "27eb0ae77836989a3bc541ce55595e8ceee0992807f14511552a898ddd0d88ac"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   dbus:
     dependency: transitive
     description:
@@ -197,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: "16ed7b077ef01ad6170a3d0c57caa4a112a38d7a2ed5602e0aca9ca6f3d98da6"
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -255,26 +263,26 @@ packages:
     dependency: transitive
     description:
       name: gql
-      sha256: "650e79ed60c21579ca3bd17ebae8a8c8d22cde267b03a19bf3b35996baaa843a"
+      sha256: "67c32325eb55c15f526f0f5e7d8b38a463dbff2ec3c2e046be4a1a95f0dc93d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1730759315362"
+    version: "1.0.1"
   gql_code_builder:
     dependency: transitive
     description:
       name: gql_code_builder
-      sha256: ce60e637b7b5250bebd6a136e5fd784bc94b860ecdcb745163ce27201023816e
+      sha256: ad16d7cca772439c2a45d0ea47f9f526dea5f6c97b9e955a42a7a7b979602a5f
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.15.1"
   gql_code_builder_serializers:
     dependency: transitive
     description:
       name: gql_code_builder_serializers
-      sha256: "5344091f97afb44b15840e32889cacc18116e095105d07671ba762e897c465d4"
+      sha256: ad8554da95de9f218c744518fcb55b6f94ffde4659aa50479eaae05855645877
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.0+1"
   gql_dedupe_link:
     dependency: transitive
     description:
@@ -287,10 +295,10 @@ packages:
     dependency: transitive
     description:
       name: gql_error_link
-      sha256: "93901458f3c050e33386dedb0ca7173e08cebd7078e4e0deca4bf23ab7a71f63"
+      sha256: dd0f3fbfbcec848ea050507470cdb5d3dc47d29544ae11044a1c883cbe159ccc
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+1"
+    version: "1.0.1"
   gql_exec:
     dependency: transitive
     description:
@@ -303,34 +311,34 @@ packages:
     dependency: transitive
     description:
       name: gql_http_link
-      sha256: ef6ad24d31beb5a30113e9b919eec20876903cc4b0ee0d31550047aaaba7d5dd
+      sha256: "07635e85a4f313836904961904417fd27844fe8f68f77b410a4e6b81d8e9202e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   gql_link:
     dependency: transitive
     description:
       name: gql_link
-      sha256: c2b0adb2f6a60c2599b9128fb095316db5feb99ce444c86fb141a6964acedfa4
+      sha256: "0730276ce3a6a0ced073194ff923a8d99b3c78e442cbf096eb54fd0c3fa9f974"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1730759315378"
+    version: "1.1.0"
   gql_transform_link:
     dependency: transitive
     description:
       name: gql_transform_link
-      sha256: "0645fdd874ca1be695fd327271fdfb24c0cd6fa40774a64b946062f321a59709"
+      sha256: b3bb06a6991bc5c9d877e2757455f80e2c14dc684b8327bedae4f4ee67afae8b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   gql_tristate_value:
     dependency: transitive
     description:
       name: gql_tristate_value
-      sha256: ae045e7e272fbfd030084315140c683c9b032a9861a37165f68c2ecd8a759664
+      sha256: "2fdf2b9364bb2164fe7d23696d6128e8f76660941521a4851a4c19a2983422f5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   graphql:
     dependency: "direct main"
     description:
@@ -345,7 +353,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.4"
+    version: "2.0.0"
   graphql_flutter:
     dependency: "direct main"
     description:
@@ -374,10 +382,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: fe7ab022b76f3034adc518fb6ea04a82387620e19977665ea18d30a1cf43442f
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -406,10 +414,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
+      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -486,10 +494,10 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: "92d4488434b520a62570293fbd33bb556c7d49230791c1b4bbd973baf6d2dc67"
+      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.2.0"
   path:
     dependency: transitive
     description:
@@ -510,18 +518,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.15"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -550,10 +558,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -574,18 +582,18 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "7b3cfbf654f3edd0c6298ecd5be782ce997ddf0e00531b9464b55245185bbbbd"
+      sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   pubspec_parse:
     dependency: transitive
     description:
@@ -638,10 +646,10 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: cc36c297b52866d203dbf9332263c94becc2fe0ceaa9681d07b6ef9807023b67
+      sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -723,26 +731,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "8391fbe68d520daf2314121764d38e37f934c02fd7301ad18307bd93bd6b725d"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.25.14"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "84d17c3486c8dfdbe5e12a50c8ae176d15e2a771b96909a9442b40173649ccaa"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.8"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:
@@ -779,42 +787,42 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "15.0.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "69da27e49efa56a15f8afe8f4438c4ec02eff0a117df1b22ea4aad194fe1c104"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:
       name: web
-      sha256: cd3543bd5798f6ad290ea73d210f423502e71900302dde696f8bff84bf89a1cb
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   web_socket:
     dependency: transitive
     description:
       name: web_socket
-      sha256: "3c12d96c0c9a4eec095246debcea7b86c0324f22df69893d538fcc6f1b8cce83"
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.6"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "0b8e2457400d8a859b7b2030786835a28a8e80836ef64402abef392ff4f1d0e5"
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -835,10 +843,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:
@@ -848,5 +856,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/packages/graphql_codegen/pubspec.lock
+++ b/packages/graphql_codegen/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "89.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: b1ade5707ab7a90dfd519eaac78a7184341d19adb6096c68d499b59c7c6cf880
+      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
       url: "https://pub.dev"
     source: hosted
-    version: "7.7.0"
+    version: "8.2.0"
   args:
     dependency: transitive
     description:
@@ -45,18 +45,18 @@ packages:
     dependency: "direct main"
     description:
       name: build
-      sha256: "7d95cbbb1526ab5ae977df9b4cc660963b9b27f6d1075c0b34653868911385e4"
+      sha256: "825fed4d63050252a0b6e74f2d75844c4a85b664814be6993bd3493fb5239779"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "4.0.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
   build_daemon:
     dependency: transitive
     description:
@@ -65,38 +65,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: "38c9c339333a09b090a638849a4c56e70a404c6bdd3b511493addfbc113b60c2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b971d4a1c789eba7be3e6fe6ce5e5b50fd3719e3cb485b3fad6d04358304351d
+      sha256: "4e54dbeefdc70691ba80b3bce3976af63b5425c8c07dface348dfee664a0edc1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.0"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: c04e612ca801cd0928ccdb891c263a2b1391cb27940a5ea5afcf9ba894de5d62
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.2.0"
+    version: "2.9.0"
   build_test:
     dependency: "direct dev"
     description:
       name: build_test
-      sha256: "090115dcc4a30c2e1dc0fdefbaa57d0d8d0237c964636bd7ba6928cfde9bf92f"
+      sha256: e2c97c203e4ff8871fd4bc7b4d7a879f991214d505ba29386e90c5bfb6202acf
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.4.1"
   built_collection:
     dependency: "direct main"
     description:
@@ -109,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: built_value
-      sha256: "082001b5c3dc495d4a42f1d5789990505df20d8547d42507c29050af6933ee27"
+      sha256: a30f0a0e38671e89a492c44d005b5545b830a961575bbd8336d42869ff71066d
       url: "https://pub.dev"
     source: hosted
-    version: "8.10.1"
+    version: "8.12.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -133,10 +117,10 @@ packages:
     dependency: "direct main"
     description:
       name: code_builder
-      sha256: "0ec10bf4a89e4c613960bf1e8b42c64127021740fb21640c29c909826a5eea3e"
+      sha256: "11654819532ba94c34de52ff5feb52bd81cba1de00ef2ed622fd50295f9d4243"
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.1"
+    version: "4.11.0"
   collection:
     dependency: transitive
     description:
@@ -181,10 +165,10 @@ packages:
     dependency: "direct main"
     description:
       name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
+      sha256: c87dfe3d56f183ffe9106a18aebc6db431fc7c98c31a54b952a77f3d54a85697
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.2"
   file:
     dependency: transitive
     description:
@@ -221,26 +205,26 @@ packages:
     dependency: "direct main"
     description:
       name: gql
-      sha256: "650e79ed60c21579ca3bd17ebae8a8c8d22cde267b03a19bf3b35996baaa843a"
+      sha256: "67c32325eb55c15f526f0f5e7d8b38a463dbff2ec3c2e046be4a1a95f0dc93d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1730759315362"
+    version: "1.0.1"
   gql_code_builder:
     dependency: "direct main"
     description:
       name: gql_code_builder
-      sha256: ce60e637b7b5250bebd6a136e5fd784bc94b860ecdcb745163ce27201023816e
+      sha256: ad16d7cca772439c2a45d0ea47f9f526dea5f6c97b9e955a42a7a7b979602a5f
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.1"
+    version: "0.15.1"
   gql_code_builder_serializers:
     dependency: transitive
     description:
       name: gql_code_builder_serializers
-      sha256: "5344091f97afb44b15840e32889cacc18116e095105d07671ba762e897c465d4"
+      sha256: ad8554da95de9f218c744518fcb55b6f94ffde4659aa50479eaae05855645877
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.0"
+    version: "0.1.0+1"
   gql_dedupe_link:
     dependency: transitive
     description:
@@ -253,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: gql_error_link
-      sha256: "93901458f3c050e33386dedb0ca7173e08cebd7078e4e0deca4bf23ab7a71f63"
+      sha256: dd0f3fbfbcec848ea050507470cdb5d3dc47d29544ae11044a1c883cbe159ccc
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0+1"
+    version: "1.0.1"
   gql_exec:
     dependency: transitive
     description:
@@ -269,42 +253,42 @@ packages:
     dependency: transitive
     description:
       name: gql_http_link
-      sha256: ef6ad24d31beb5a30113e9b919eec20876903cc4b0ee0d31550047aaaba7d5dd
+      sha256: "07635e85a4f313836904961904417fd27844fe8f68f77b410a4e6b81d8e9202e"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   gql_link:
     dependency: transitive
     description:
       name: gql_link
-      sha256: c2b0adb2f6a60c2599b9128fb095316db5feb99ce444c86fb141a6964acedfa4
+      sha256: "0730276ce3a6a0ced073194ff923a8d99b3c78e442cbf096eb54fd0c3fa9f974"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1-alpha+1730759315378"
+    version: "1.1.0"
   gql_transform_link:
     dependency: transitive
     description:
       name: gql_transform_link
-      sha256: "0645fdd874ca1be695fd327271fdfb24c0cd6fa40774a64b946062f321a59709"
+      sha256: b3bb06a6991bc5c9d877e2757455f80e2c14dc684b8327bedae4f4ee67afae8b
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   gql_tristate_value:
     dependency: transitive
     description:
       name: gql_tristate_value
-      sha256: ae045e7e272fbfd030084315140c683c9b032a9861a37165f68c2ecd8a759664
+      sha256: "2fdf2b9364bb2164fe7d23696d6128e8f76660941521a4851a4c19a2983422f5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   graphql:
     dependency: "direct dev"
     description:
       name: graphql
-      sha256: "735bbbaa4db10d38054932e726d291bdd46e46e0575cd482a74b0615b8622e1c"
+      sha256: "2011435a7fea92fff5b02c77550a54f89427a3c33c92cd2fccfd3aa87ed3727d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.1"
+    version: "5.2.2"
   graphs:
     dependency: transitive
     description:
@@ -333,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -381,10 +365,10 @@ packages:
     dependency: "direct dev"
     description:
       name: json_serializable
-      sha256: ab72b330200c008cd9ece5a8383226ea11b4bd88a3afa62d1f574b436c666393
+      sha256: "33a040668b31b320aafa4822b7b1e177e163fc3c1e835c6750319d4ab23aa6fe"
       url: "https://pub.dev"
     source: hosted
-    version: "6.10.0-dev"
+    version: "6.11.1"
   lints:
     dependency: "direct dev"
     description:
@@ -461,10 +445,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -533,18 +517,18 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: b9e3027417cb348083c375318f3aa993a8f54508d0e1defe332ce6baa8516333
+      sha256: ccf30b0c9fbcd79d8b6f5bfac23199fb354938436f62475e14aea0f29ee0f800
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0-dev"
+    version: "4.0.1"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
-      sha256: "4f81479fe5194a622cdd1713fe1ecb683a6e6c85cd8cec8e2e35ee5ab3fdf2a1"
+      sha256: "6a3c6cc82073a8797f8c4dc4572146114a39652851c157db37e964d9c7038723"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.8"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -621,34 +605,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -677,10 +653,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:
@@ -722,4 +698,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <4.0.0"
+  dart: ">=3.9.0 <4.0.0"

--- a/packages/graphql_codegen/pubspec.yaml
+++ b/packages/graphql_codegen/pubspec.yaml
@@ -12,19 +12,19 @@ environment:
 
 dependencies:
   gql: ^1.0.0
-  build: ">=2.0.1 <4.0.0"
+  build: ">=4.0.0 <5.0.0"
   glob: ^2.0.1
   code_builder: ^4.2.0
   dart_style: ^3.0.0
   built_collection: ^5.0.0
   path: ^1.8.0
-  gql_code_builder: ^0.13.1
+  gql_code_builder: ^0.15.1
   recase: ^4.0.0
   json_annotation: ^4.9.0
 dev_dependencies:
   test: ^1.17.4
   build_test: ^3.3.0
-  build_runner: ^2.0.3
+  build_runner: ^2.9.0
   json_serializable: ^6.9.5
-  graphql: ^5.2.0-beta.3
+  graphql: ^5.2.2
   lints: ^5.1.1

--- a/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/add_typenames/schema.graphql.dart
@@ -864,6 +864,7 @@ extension UtilityExtension$Query$Q$docsWithTypename
     on Query$Q$docsWithTypename {
   CopyWith$Query$Q$docsWithTypename<Query$Q$docsWithTypename> get copyWith =>
       CopyWith$Query$Q$docsWithTypename(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$docsWithTypename$$Contract) contract,
     required _T Function(Query$Q$docsWithTypename$$Report) report,
@@ -1197,6 +1198,7 @@ extension UtilityExtension$Query$Q$docsWihtoutTypename
     on Query$Q$docsWihtoutTypename {
   CopyWith$Query$Q$docsWihtoutTypename<Query$Q$docsWihtoutTypename>
   get copyWith => CopyWith$Query$Q$docsWihtoutTypename(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$docsWihtoutTypename$$Contract) contract,
     required _T Function(Query$Q$docsWihtoutTypename$$Report) report,
@@ -1847,6 +1849,7 @@ extension UtilityExtension$Query$Q$docsWithFragment
     on Query$Q$docsWithFragment {
   CopyWith$Query$Q$docsWithFragment<Query$Q$docsWithFragment> get copyWith =>
       CopyWith$Query$Q$docsWithFragment(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$docsWithFragment$$Contract) contract,
     required _T Function(Query$Q$docsWithFragment$$Report) report,

--- a/packages/graphql_codegen/test/assets/condition_example/fragments.graphql.dart
+++ b/packages/graphql_codegen/test/assets/condition_example/fragments.graphql.dart
@@ -66,6 +66,7 @@ class Fragment$Condition {
 extension UtilityExtension$Fragment$Condition on Fragment$Condition {
   CopyWith$Fragment$Condition<Fragment$Condition> get copyWith =>
       CopyWith$Fragment$Condition(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$Condition$$AndCondition) andCondition,
     required _T Function(Fragment$Condition$$TimeCondition) timeCondition,
@@ -721,6 +722,7 @@ extension UtilityExtension$Fragment$CompositeCondition
     on Fragment$CompositeCondition {
   CopyWith$Fragment$CompositeCondition<Fragment$CompositeCondition>
   get copyWith => CopyWith$Fragment$CompositeCondition(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$CompositeCondition$$AndCondition)
     andCondition,
@@ -1260,6 +1262,7 @@ extension UtilityExtension$Fragment$NonCompositeCondition
     on Fragment$NonCompositeCondition {
   CopyWith$Fragment$NonCompositeCondition<Fragment$NonCompositeCondition>
   get copyWith => CopyWith$Fragment$NonCompositeCondition(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$NonCompositeCondition$$AndCondition)
     andCondition,

--- a/packages/graphql_codegen/test/assets/fragment_and_field/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_and_field/document.graphql.dart
@@ -535,6 +535,7 @@ class Query$Q$person {
 extension UtilityExtension$Query$Q$person on Query$Q$person {
   CopyWith$Query$Q$person<Query$Q$person> get copyWith =>
       CopyWith$Query$Q$person(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$person$$Person) person,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragment_variables_2/schema.graphql.dart
@@ -427,6 +427,7 @@ extension ClientExtension$Fragment$NameNode on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$NameNode? readFragment$NameNode({
     required Map<String, dynamic> idFields,
     required Variables$Fragment$NameNode variables,
@@ -791,8 +792,10 @@ class FetchMoreOptions$Query$Q extends graphql.FetchMoreOptions {
 extension ClientExtension$Query$Q on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$Q>> query$Q(Options$Query$Q options) async =>
       await this.query(options);
+
   graphql.ObservableQuery<Query$Q> watchQuery$Q(WatchOptions$Query$Q options) =>
       this.watchQuery(options);
+
   void writeQuery$Q({
     required Query$Q data,
     required Variables$Query$Q variables,
@@ -805,6 +808,7 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$Q? readQuery$Q({
     required Variables$Query$Q variables,
     bool optimistic = true,

--- a/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/fragments_and_loose_type_requirements/document.graphql.dart
@@ -244,6 +244,7 @@ class Fragment$F {
 extension UtilityExtension$Fragment$F on Fragment$F {
   CopyWith$Fragment$F<Fragment$F> get copyWith =>
       CopyWith$Fragment$F(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$F$$T) t,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client/document.graphql.dart
@@ -307,6 +307,7 @@ extension ClientExtension$Fragment$NoVariables on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$NoVariables? readFragment$NoVariables({
     required Map<String, dynamic> idFields,
     bool optimistic = true,
@@ -563,6 +564,7 @@ extension ClientExtension$Fragment$WithOptionalVariables
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$WithOptionalVariables? readFragment$WithOptionalVariables({
     required Map<String, dynamic> idFields,
     Variables$Fragment$WithOptionalVariables? variables,
@@ -803,6 +805,7 @@ extension ClientExtension$Fragment$WithVariables on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$WithVariables? readFragment$WithVariables({
     required Map<String, dynamic> idFields,
     required Variables$Fragment$WithVariables variables,
@@ -1136,9 +1139,11 @@ extension ClientExtension$Query$FetchSOptional on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSOptional>> query$FetchSOptional([
     Options$Query$FetchSOptional? options,
   ]) async => await this.query(options ?? Options$Query$FetchSOptional());
+
   graphql.ObservableQuery<Query$FetchSOptional> watchQuery$FetchSOptional([
     WatchOptions$Query$FetchSOptional? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$FetchSOptional());
+
   void writeQuery$FetchSOptional({
     required Query$FetchSOptional data,
     Variables$Query$FetchSOptional? variables,
@@ -1151,6 +1156,7 @@ extension ClientExtension$Query$FetchSOptional on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSOptional? readQuery$FetchSOptional({
     Variables$Query$FetchSOptional? variables,
     bool optimistic = true,
@@ -1469,9 +1475,11 @@ extension ClientExtension$Query$FetchSRequired on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSRequired>> query$FetchSRequired(
     Options$Query$FetchSRequired options,
   ) async => await this.query(options);
+
   graphql.ObservableQuery<Query$FetchSRequired> watchQuery$FetchSRequired(
     WatchOptions$Query$FetchSRequired options,
   ) => this.watchQuery(options);
+
   void writeQuery$FetchSRequired({
     required Query$FetchSRequired data,
     required Variables$Query$FetchSRequired variables,
@@ -1484,6 +1492,7 @@ extension ClientExtension$Query$FetchSRequired on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSRequired? readQuery$FetchSRequired({
     required Variables$Query$FetchSRequired variables,
     bool optimistic = true,
@@ -1700,10 +1709,12 @@ extension ClientExtension$Query$FetchSNoVariables on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSNoVariables>> query$FetchSNoVariables([
     Options$Query$FetchSNoVariables? options,
   ]) async => await this.query(options ?? Options$Query$FetchSNoVariables());
+
   graphql.ObservableQuery<Query$FetchSNoVariables>
   watchQuery$FetchSNoVariables([
     WatchOptions$Query$FetchSNoVariables? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$FetchSNoVariables());
+
   void writeQuery$FetchSNoVariables({
     required Query$FetchSNoVariables data,
     bool broadcast = true,
@@ -1716,6 +1727,7 @@ extension ClientExtension$Query$FetchSNoVariables on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSNoVariables? readQuery$FetchSNoVariables({
     bool optimistic = true,
   }) {
@@ -2039,6 +2051,7 @@ extension ClientExtension$Mutation$UpdateSOptional on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSOptional>> mutate$UpdateSOptional([
     Options$Mutation$UpdateSOptional? options,
   ]) async => await this.mutate(options ?? Options$Mutation$UpdateSOptional());
+
   graphql.ObservableQuery<Mutation$UpdateSOptional>
   watchMutation$UpdateSOptional([
     WatchOptions$Mutation$UpdateSOptional? options,
@@ -2343,6 +2356,7 @@ extension ClientExtension$Mutation$UpdateSRequired on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSRequired>> mutate$UpdateSRequired(
     Options$Mutation$UpdateSRequired options,
   ) async => await this.mutate(options);
+
   graphql.ObservableQuery<Mutation$UpdateSRequired>
   watchMutation$UpdateSRequired(
     WatchOptions$Mutation$UpdateSRequired options,
@@ -2551,6 +2565,7 @@ extension ClientExtension$Mutation$UpdateSNoVariables on graphql.GraphQLClient {
     Options$Mutation$UpdateSNoVariables? options,
   ]) async =>
       await this.mutate(options ?? Options$Mutation$UpdateSNoVariables());
+
   graphql.ObservableQuery<Mutation$UpdateSNoVariables>
   watchMutation$UpdateSNoVariables([
     WatchOptions$Mutation$UpdateSNoVariables? options,

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document.graphql.dart
@@ -376,6 +376,7 @@ extension ClientExtension$Fragment$F1 on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$F1? readFragment$F1({
     required Map<String, dynamic> idFields,
     bool optimistic = true,

--- a/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_client_nested_fragments/document2.graphql.dart
@@ -145,6 +145,7 @@ extension ClientExtension$Fragment$F2 on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Fragment$F2? readFragment$F2({
     required Map<String, dynamic> idFields,
     bool optimistic = true,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_infer_graphql_client/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_infer_graphql_client/document.graphql.dart
@@ -375,6 +375,7 @@ extension ClientExtension$Mutation$UpdateSNo on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSNo>> mutate$UpdateSNo([
     Options$Mutation$UpdateSNo? options,
   ]) async => await this.mutate(options ?? Options$Mutation$UpdateSNo());
+
   graphql.ObservableQuery<Mutation$UpdateSNo> watchMutation$UpdateSNo([
     WatchOptions$Mutation$UpdateSNo? options,
   ]) => this.watchMutation(options ?? WatchOptions$Mutation$UpdateSNo());

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_no_arguments/document.graphql.dart
@@ -375,6 +375,7 @@ extension ClientExtension$Mutation$UpdateSNo on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSNo>> mutate$UpdateSNo([
     Options$Mutation$UpdateSNo? options,
   ]) async => await this.mutate(options ?? Options$Mutation$UpdateSNo());
+
   graphql.ObservableQuery<Mutation$UpdateSNo> watchMutation$UpdateSNo([
     WatchOptions$Mutation$UpdateSNo? options,
   ]) => this.watchMutation(options ?? WatchOptions$Mutation$UpdateSNo());

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_optional_arguments/document.graphql.dart
@@ -493,6 +493,7 @@ extension ClientExtension$Mutation$UpdateSOptional on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSOptional>> mutate$UpdateSOptional([
     Options$Mutation$UpdateSOptional? options,
   ]) async => await this.mutate(options ?? Options$Mutation$UpdateSOptional());
+
   graphql.ObservableQuery<Mutation$UpdateSOptional>
   watchMutation$UpdateSOptional([
     WatchOptions$Mutation$UpdateSOptional? options,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_mutation_required_arguments/document.graphql.dart
@@ -483,6 +483,7 @@ extension ClientExtension$Mutation$UpdateSRequired on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$UpdateSRequired>> mutate$UpdateSRequired(
     Options$Mutation$UpdateSRequired options,
   ) async => await this.mutate(options);
+
   graphql.ObservableQuery<Mutation$UpdateSRequired>
   watchMutation$UpdateSRequired(
     WatchOptions$Mutation$UpdateSRequired options,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_no_arguments/document.graphql.dart
@@ -386,10 +386,12 @@ extension ClientExtension$Query$FetchSNoVariables on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSNoVariables>> query$FetchSNoVariables([
     Options$Query$FetchSNoVariables? options,
   ]) async => await this.query(options ?? Options$Query$FetchSNoVariables());
+
   graphql.ObservableQuery<Query$FetchSNoVariables>
   watchQuery$FetchSNoVariables([
     WatchOptions$Query$FetchSNoVariables? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$FetchSNoVariables());
+
   void writeQuery$FetchSNoVariables({
     required Query$FetchSNoVariables data,
     bool broadcast = true,
@@ -402,6 +404,7 @@ extension ClientExtension$Query$FetchSNoVariables on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSNoVariables? readQuery$FetchSNoVariables({
     bool optimistic = true,
   }) {

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_optional_arguments/document.graphql.dart
@@ -498,9 +498,11 @@ extension ClientExtension$Query$FetchSOptional on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSOptional>> query$FetchSOptional([
     Options$Query$FetchSOptional? options,
   ]) async => await this.query(options ?? Options$Query$FetchSOptional());
+
   graphql.ObservableQuery<Query$FetchSOptional> watchQuery$FetchSOptional([
     WatchOptions$Query$FetchSOptional? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$FetchSOptional());
+
   void writeQuery$FetchSOptional({
     required Query$FetchSOptional data,
     Variables$Query$FetchSOptional? variables,
@@ -513,6 +515,7 @@ extension ClientExtension$Query$FetchSOptional on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSOptional? readQuery$FetchSOptional({
     Variables$Query$FetchSOptional? variables,
     bool optimistic = true,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_query_required_arguments/document.graphql.dart
@@ -488,9 +488,11 @@ extension ClientExtension$Query$FetchSRequired on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$FetchSRequired>> query$FetchSRequired(
     Options$Query$FetchSRequired options,
   ) async => await this.query(options);
+
   graphql.ObservableQuery<Query$FetchSRequired> watchQuery$FetchSRequired(
     WatchOptions$Query$FetchSRequired options,
   ) => this.watchQuery(options);
+
   void writeQuery$FetchSRequired({
     required Query$FetchSRequired data,
     required Variables$Query$FetchSRequired variables,
@@ -503,6 +505,7 @@ extension ClientExtension$Query$FetchSRequired on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$FetchSRequired? readQuery$FetchSRequired({
     required Variables$Query$FetchSRequired variables,
     bool optimistic = true,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_client_subscription/schema.graphql.dart
@@ -430,6 +430,7 @@ extension ClientExtension$Subscription$NoArgs on graphql.GraphQLClient {
   Stream<graphql.QueryResult<Subscription$NoArgs>> subscribe$NoArgs([
     Options$Subscription$NoArgs? options,
   ]) => this.subscribe(options ?? Options$Subscription$NoArgs());
+
   graphql.ObservableQuery<Subscription$NoArgs> watchSubscription$NoArgs([
     WatchOptions$Subscription$NoArgs? options,
   ]) => this.watchQuery(options ?? WatchOptions$Subscription$NoArgs());
@@ -930,6 +931,7 @@ extension ClientExtension$Subscription$RequiredArg on graphql.GraphQLClient {
   Stream<graphql.QueryResult<Subscription$RequiredArg>> subscribe$RequiredArg(
     Options$Subscription$RequiredArg options,
   ) => this.subscribe(options);
+
   graphql.ObservableQuery<Subscription$RequiredArg>
   watchSubscription$RequiredArg(
     WatchOptions$Subscription$RequiredArg options,
@@ -1446,6 +1448,7 @@ extension ClientExtension$Subscription$OptionalArg on graphql.GraphQLClient {
   Stream<graphql.QueryResult<Subscription$OptionalArg>> subscribe$OptionalArg([
     Options$Subscription$OptionalArg? options,
   ]) => this.subscribe(options ?? Options$Subscription$OptionalArg());
+
   graphql.ObservableQuery<Subscription$OptionalArg>
   watchSubscription$OptionalArg([
     WatchOptions$Subscription$OptionalArg? options,

--- a/packages/graphql_codegen/test/assets/graphql_flutter_naming_config/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/graphql_flutter_naming_config/document.graphql.dart
@@ -547,9 +547,11 @@ extension ClientExtension___Query___Q on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query___Q>> query___Q([
     Options___Query___Q? options,
   ]) async => await this.query(options ?? Options___Query___Q());
+
   graphql.ObservableQuery<Query___Q> watchQuery___Q([
     WatchOptions___Query___Q? options,
   ]) => this.watchQuery(options ?? WatchOptions___Query___Q());
+
   void writeQuery___Q({required Query___Q data, bool broadcast = true}) =>
       this.writeQuery(
         graphql.Request(
@@ -558,6 +560,7 @@ extension ClientExtension___Query___Q on graphql.GraphQLClient {
         data: data.toJson(),
         broadcast: broadcast,
       );
+
   Query___Q? readQuery___Q({bool optimistic = true}) {
     final result = this.readQuery(
       graphql.Request(

--- a/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interface_and_fragments/query.graphql.dart
@@ -540,6 +540,7 @@ extension UtilityExtension$Query$FetchImplementations$interface
     Query$FetchImplementations$interface
   >
   get copyWith => CopyWith$Query$FetchImplementations$interface(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchImplementations$interface$$ImplementationA)
     implementationA,
@@ -731,6 +732,7 @@ extension UtilityExtension$Query$FetchImplementations$interface$self
   >
   get copyWith =>
       CopyWith$Query$FetchImplementations$interface$self(this, (i) => i);
+
   _T when<_T>({
     required _T Function(
       Query$FetchImplementations$interface$self$$ImplementationA,

--- a/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/interfaces_and_concrete_types/document.graphql.dart
@@ -583,6 +583,7 @@ class Query$FetchI$i1 {
 extension UtilityExtension$Query$FetchI$i1 on Query$FetchI$i1 {
   CopyWith$Query$FetchI$i1<Query$FetchI$i1> get copyWith =>
       CopyWith$Query$FetchI$i1(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchI$i1$$T1) t1,
     required _T Function() orElse,
@@ -734,6 +735,7 @@ class Query$FetchI$i1$i2 {
 extension UtilityExtension$Query$FetchI$i1$i2 on Query$FetchI$i1$i2 {
   CopyWith$Query$FetchI$i1$i2<Query$FetchI$i1$i2> get copyWith =>
       CopyWith$Query$FetchI$i1$i2(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchI$i1$i2$$T2) t2,
     required _T Function() orElse,
@@ -885,6 +887,7 @@ extension UtilityExtension$Query$FetchI$i1$i2$field
     on Query$FetchI$i1$i2$field {
   CopyWith$Query$FetchI$i1$i2$field<Query$FetchI$i1$i2$field> get copyWith =>
       CopyWith$Query$FetchI$i1$i2$field(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchI$i1$i2$field$$TField) tField,
     required _T Function() orElse,
@@ -1729,6 +1732,7 @@ class Query$FetchI$i1$$T1$i2 implements Query$FetchI$i1$i2 {
 extension UtilityExtension$Query$FetchI$i1$$T1$i2 on Query$FetchI$i1$$T1$i2 {
   CopyWith$Query$FetchI$i1$$T1$i2<Query$FetchI$i1$$T1$i2> get copyWith =>
       CopyWith$Query$FetchI$i1$$T1$i2(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchI$i1$$T1$i2$$T2) t2,
     required _T Function() orElse,
@@ -1883,6 +1887,7 @@ extension UtilityExtension$Query$FetchI$i1$$T1$i2$field
     on Query$FetchI$i1$$T1$i2$field {
   CopyWith$Query$FetchI$i1$$T1$i2$field<Query$FetchI$i1$$T1$i2$field>
   get copyWith => CopyWith$Query$FetchI$i1$$T1$i2$field(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchI$i1$$T1$i2$field$$TField) tField,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/issue_158/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_158/document.graphql.dart
@@ -244,6 +244,7 @@ class Fragment$PersonSummary {
 extension UtilityExtension$Fragment$PersonSummary on Fragment$PersonSummary {
   CopyWith$Fragment$PersonSummary<Fragment$PersonSummary> get copyWith =>
       CopyWith$Fragment$PersonSummary(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$PersonSummary$$Person) person,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/issue_168/schema.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_168/schema.graphql.dart
@@ -946,6 +946,7 @@ extension UtilityExtension$Query$WalletGetContent$walletGetContent$blocks
   >
   get copyWith =>
       CopyWith$Query$WalletGetContent$walletGetContent$blocks(this, (i) => i);
+
   _T when<_T>({
     required _T Function(
       Query$WalletGetContent$walletGetContent$blocks$$WalletContentBlockList,
@@ -1553,6 +1554,7 @@ extension UtilityExtension$Query$WalletGetContent$walletGetContent$blocks$$Walle
         this,
         (i) => i,
       );
+
   _T when<_T>({
     required _T Function(
       Query$WalletGetContent$walletGetContent$blocks$$WalletContentBlockList$items$$WalletContentItemContentPreview,

--- a/packages/graphql_codegen/test/assets/issue_191/mutation.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/mutation.graphql.dart
@@ -209,6 +209,7 @@ extension ClientExtension$Mutation$M on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$M>> mutate$M([
     Options$Mutation$M? options,
   ]) async => await this.mutate(options ?? Options$Mutation$M());
+
   graphql.ObservableQuery<Mutation$M> watchMutation$M([
     WatchOptions$Mutation$M? options,
   ]) => this.watchMutation(options ?? WatchOptions$Mutation$M());

--- a/packages/graphql_codegen/test/assets/issue_191/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/query.graphql.dart
@@ -210,9 +210,11 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$Q>> query$Q([
     Options$Query$Q? options,
   ]) async => await this.query(options ?? Options$Query$Q());
+
   graphql.ObservableQuery<Query$Q> watchQuery$Q([
     WatchOptions$Query$Q? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$Q());
+
   void writeQuery$Q({required Query$Q data, bool broadcast = true}) =>
       this.writeQuery(
         graphql.Request(
@@ -221,6 +223,7 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
         data: data.toJson(),
         broadcast: broadcast,
       );
+
   Query$Q? readQuery$Q({bool optimistic = true}) {
     final result = this.readQuery(
       graphql.Request(

--- a/packages/graphql_codegen/test/assets/issue_191/subscription.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_191/subscription.graphql.dart
@@ -195,6 +195,7 @@ extension ClientExtension$Subscription$S on graphql.GraphQLClient {
   Stream<graphql.QueryResult<Subscription$S>> subscribe$S([
     Options$Subscription$S? options,
   ]) => this.subscribe(options ?? Options$Subscription$S());
+
   graphql.ObservableQuery<Subscription$S> watchSubscription$S([
     WatchOptions$Subscription$S? options,
   ]) => this.watchQuery(options ?? WatchOptions$Subscription$S());

--- a/packages/graphql_codegen/test/assets/issue_192/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_192/document.graphql.dart
@@ -424,6 +424,7 @@ class Query$Q$book {
 extension UtilityExtension$Query$Q$book on Query$Q$book {
   CopyWith$Query$Q$book<Query$Q$book> get copyWith =>
       CopyWith$Query$Q$book(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$book$$TextBook) textBook,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/issue_206/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_206/document.graphql.dart
@@ -248,6 +248,7 @@ class Fragment$EventFragment {
 extension UtilityExtension$Fragment$EventFragment on Fragment$EventFragment {
   CopyWith$Fragment$EventFragment<Fragment$EventFragment> get copyWith =>
       CopyWith$Fragment$EventFragment(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$EventFragment$$EventPublic) eventPublic,
     required _T Function() orElse,
@@ -1190,6 +1191,7 @@ class Mutation$Bla$bla {
 extension UtilityExtension$Mutation$Bla$bla on Mutation$Bla$bla {
   CopyWith$Mutation$Bla$bla<Mutation$Bla$bla> get copyWith =>
       CopyWith$Mutation$Bla$bla(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Mutation$Bla$bla$$EventPublic) eventPublic,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaA/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaA/document.graphql.dart
@@ -388,9 +388,11 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$Q>> query$Q([
     Options$Query$Q? options,
   ]) async => await this.query(options ?? Options$Query$Q());
+
   graphql.ObservableQuery<Query$Q> watchQuery$Q([
     WatchOptions$Query$Q? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$Q());
+
   void writeQuery$Q({required Query$Q data, bool broadcast = true}) =>
       this.writeQuery(
         graphql.Request(
@@ -399,6 +401,7 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
         data: data.toJson(),
         broadcast: broadcast,
       );
+
   Query$Q? readQuery$Q({bool optimistic = true}) {
     final result = this.readQuery(
       graphql.Request(

--- a/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaB/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_229/lib/generated/schemaB/document.graphql.dart
@@ -388,9 +388,11 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$Q>> query$Q([
     Options$Query$Q? options,
   ]) async => await this.query(options ?? Options$Query$Q());
+
   graphql.ObservableQuery<Query$Q> watchQuery$Q([
     WatchOptions$Query$Q? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$Q());
+
   void writeQuery$Q({required Query$Q data, bool broadcast = true}) =>
       this.writeQuery(
         graphql.Request(
@@ -399,6 +401,7 @@ extension ClientExtension$Query$Q on graphql.GraphQLClient {
         data: data.toJson(),
         broadcast: broadcast,
       );
+
   Query$Q? readQuery$Q({bool optimistic = true}) {
     final result = this.readQuery(
       graphql.Request(

--- a/packages/graphql_codegen/test/assets/issue_239/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_239/document.graphql.dart
@@ -579,6 +579,7 @@ class Query$Q$booking {
 extension UtilityExtension$Query$Q$booking on Query$Q$booking {
   CopyWith$Query$Q$booking<Query$Q$booking> get copyWith =>
       CopyWith$Query$Q$booking(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$booking$$HotelBooking) hotelBooking,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/issue_288/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/issue_288/document.graphql.dart
@@ -850,6 +850,7 @@ extension UtilityExtension$Fragment$FullUser$notifications
     on Fragment$FullUser$notifications {
   CopyWith$Fragment$FullUser$notifications<Fragment$FullUser$notifications>
   get copyWith => CopyWith$Fragment$FullUser$notifications(this, (i) => i);
+
   _T when<_T>({
     required _T Function(
       Fragment$FullUser$notifications$$FriendRequestNotification,
@@ -2034,6 +2035,7 @@ extension UtilityExtension$Query$GetNotifications$getUser$notifications
   >
   get copyWith =>
       CopyWith$Query$GetNotifications$getUser$notifications(this, (i) => i);
+
   _T when<_T>({
     required _T Function(
       Query$GetNotifications$getUser$notifications$$FriendRequestNotification,

--- a/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/lots_of_fragments/document.graphql.dart
@@ -394,6 +394,7 @@ class Fragment$FragmentI {
 extension UtilityExtension$Fragment$FragmentI on Fragment$FragmentI {
   CopyWith$Fragment$FragmentI<Fragment$FragmentI> get copyWith =>
       CopyWith$Fragment$FragmentI(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Fragment$FragmentI$$FieldA) fieldA,
     required _T Function() orElse,
@@ -884,6 +885,7 @@ class Query$FetchStuff$field {
 extension UtilityExtension$Query$FetchStuff$field on Query$FetchStuff$field {
   CopyWith$Query$FetchStuff$field<Query$FetchStuff$field> get copyWith =>
       CopyWith$Query$FetchStuff$field(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$FetchStuff$field$$FieldA) fieldA,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/multiple_interfaces/document.graphql.dart
@@ -1055,6 +1055,7 @@ class Query$Q$field implements Fragment$F0 {
 extension UtilityExtension$Query$Q$field on Query$Q$field {
   CopyWith$Query$Q$field<Query$Q$field> get copyWith =>
       CopyWith$Query$Q$field(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$field$$T1) t1,
     required _T Function() orElse,

--- a/packages/graphql_codegen/test/assets/operation_name_collision/mutation.graphql.dart
+++ b/packages/graphql_codegen/test/assets/operation_name_collision/mutation.graphql.dart
@@ -228,6 +228,7 @@ extension ClientExtension$Mutation$Operation on graphql.GraphQLClient {
   Future<graphql.QueryResult<Mutation$Operation>> mutate$Operation([
     Options$Mutation$Operation? options,
   ]) async => await this.mutate(options ?? Options$Mutation$Operation());
+
   graphql.ObservableQuery<Mutation$Operation> watchMutation$Operation([
     WatchOptions$Mutation$Operation? options,
   ]) => this.watchMutation(options ?? WatchOptions$Mutation$Operation());

--- a/packages/graphql_codegen/test/assets/operation_name_collision/query.graphql.dart
+++ b/packages/graphql_codegen/test/assets/operation_name_collision/query.graphql.dart
@@ -195,9 +195,11 @@ extension ClientExtension$Query$Operation on graphql.GraphQLClient {
   Future<graphql.QueryResult<Query$Operation>> query$Operation([
     Options$Query$Operation? options,
   ]) async => await this.query(options ?? Options$Query$Operation());
+
   graphql.ObservableQuery<Query$Operation> watchQuery$Operation([
     WatchOptions$Query$Operation? options,
   ]) => this.watchQuery(options ?? WatchOptions$Query$Operation());
+
   void writeQuery$Operation({
     required Query$Operation data,
     bool broadcast = true,
@@ -208,6 +210,7 @@ extension ClientExtension$Query$Operation on graphql.GraphQLClient {
     data: data.toJson(),
     broadcast: broadcast,
   );
+
   Query$Operation? readQuery$Operation({bool optimistic = true}) {
     final result = this.readQuery(
       graphql.Request(

--- a/packages/graphql_codegen/test/assets/unions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/unions/document.graphql.dart
@@ -391,6 +391,7 @@ class Query$Q$u {
 extension UtilityExtension$Query$Q$u on Query$Q$u {
   CopyWith$Query$Q$u<Query$Q$u> get copyWith =>
       CopyWith$Query$Q$u(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Q$u$$TA) tA,
     required _T Function(Query$Q$u$$TB) tB,

--- a/packages/graphql_codegen/test/assets/when_extensions/document.graphql.dart
+++ b/packages/graphql_codegen/test/assets/when_extensions/document.graphql.dart
@@ -458,6 +458,7 @@ class Query$Query$u {
 extension UtilityExtension$Query$Query$u on Query$Query$u {
   CopyWith$Query$Query$u<Query$Query$u> get copyWith =>
       CopyWith$Query$Query$u(this, (i) => i);
+
   _T when<_T>({
     required _T Function(Query$Query$u$$TA) tA,
     required _T Function(Query$Query$u$$TB) tB,


### PR DESCRIPTION
Upgraded various dependencies to their latest versions:
- Updated Dart SDK constraint from ">=3.8.0 <4.0.0" to ">=3.9.0 <4.0.0".
- Adjusted build dependency range to ">=4.0.0 <5.0.0".
- Updated gql_code_builder from version ^0.13.1 to ^0.15.1.
- Updated build_runner from version ^2.0.3 to ^2.9.0.
- Updated graphql from version ^5.2.0-beta.3 to ^5.2.2.

However, some tests fail. I’m not sure, but from on my understanding, it’s likely due to a formatting mismatch in more recent versions of gql_code_builder (double \n vs single \n).

Related to #404 

Thanks @budde377 