### PR TITLE
fix: Add null check before type casting in value reference

### DIFF
--- a/packages/graphql_codegen/lib/src/printer/base/json.dart
+++ b/packages/graphql_codegen/lib/src/printer/base/json.dart
@@ -65,7 +65,7 @@ Expression _printFromJsonValue(
   final valueRef = refer(value);
   if (type is ListTypeNode) {
     final cast = generic('List', refer('dynamic'), isNullable: !type.isNonNull);
-    final castedValue = valueRef.asA(cast);
+    final castedValue = valueRef.equalTo(literalNull).conditional(refer('[]'), valueRef).asA(cast);
     final mappedAccess =
         (type.isNonNull
                 ? castedValue.property('map')


### PR DESCRIPTION
When using GraphQL, one of the key benefits is querying only the data we need. However, the current implementation has an issue with relationship fields:

If we don't query a relationship field, it returns null
currently we are directly casting this null value without checking, causing runtime errors
This forced us to either:

1. Always fetch relationship data (defeating the purpose of GraphQL's selective querying), OR
2. Create duplicate fragments - one with relationships and one without (this becomes hard to maintain when we have multiple relationships)

Solution
Added a null check before type casting:
```
// Before
final castedValue = valueRef.asA(cast);

// After
final castedValue = valueRef.equalTo(literalNull)
    .conditional(refer('[]'), valueRef)
    .asA(cast);
```

    
Now when a relationship field is null (because it wasn't queried), we default it to an empty array [] instead of attempting to cast null.